### PR TITLE
Add template strings

### DIFF
--- a/Underanalyzer/Compiler/Lexer/LexContext.cs
+++ b/Underanalyzer/Compiler/Lexer/LexContext.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 
 namespace Underanalyzer.Compiler.Lexer;
 
@@ -76,8 +75,9 @@ internal sealed class LexContext : ISubCompileContext
         ReadOnlySpan<char> text = Text;
         int pos = startPosition;
         bool newStrings = CompileContext.GameContext.UsingGMS2OrLater;
-        // store brace nesting level for template string fields, e.g. $"{{}}"
-        int braceLevel = 0;
+
+        // Store brace nesting level for template string fields, e.g. $"{{}}"
+        int templateBraceLevel = 0;
 
         while (pos < text.Length)
         {
@@ -116,7 +116,7 @@ internal sealed class LexContext : ISubCompileContext
             }
             else if (currChar == '0' && nextChar == 'x')
             {
-                pos = Numbers.ParseHex(this, pos, currChar == '$');
+                pos = Numbers.ParseHex(this, pos, false);
             }
             else if (char.IsDigit(currChar) || (currChar == '.' && char.IsDigit(nextChar)))
             {
@@ -156,20 +156,21 @@ internal sealed class LexContext : ISubCompileContext
                     continue;
                 }
 
+                // If within a template string, adjust its brace level (until no braces left)
                 if (inTemplateString && Tokens[^1] is TokenSeparator sep)
                 {
                     switch (sep.Kind)
                     {
                         case SeparatorKind.BlockOpen:
-                            braceLevel++;
+                            templateBraceLevel++;
                             break;
 
                         case SeparatorKind.BlockClose:
-                            if (braceLevel == 0)
+                            if (templateBraceLevel == 0)
                             {
                                 return pos;
                             }
-                            braceLevel--;
+                            templateBraceLevel--;
                             break;
                     }
                 }
@@ -178,7 +179,7 @@ internal sealed class LexContext : ISubCompileContext
 
         if (inTemplateString)
         {
-            // if not returned yet, we are at the end of the code
+            // If not returned yet, we are at the end of the code
             CompileContext.PushError("Template string field not closed", this, startPosition);
         }
         return pos;

--- a/Underanalyzer/Compiler/Lexer/LexContext.cs
+++ b/Underanalyzer/Compiler/Lexer/LexContext.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Underanalyzer.Compiler.Lexer;
 
@@ -65,13 +66,18 @@ internal sealed class LexContext : ISubCompileContext
     }
 
     /// <summary>
-    /// Tokenizes the input text until reaching the end.
+    /// Tokenizes the input text until reaching the end, or until the template
+    /// string field is closed if the <tt>inTemplateString</tt> parameter is
+    /// <see langword="true"/>. In the latter case, the closing brace is also
+    /// consumed.
     /// </summary>
-    public void Tokenize()
+    public int Tokenize(int startPosition = 0, bool inTemplateString = false)
     {
         ReadOnlySpan<char> text = Text;
-        int pos = 0;
+        int pos = startPosition;
         bool newStrings = CompileContext.GameContext.UsingGMS2OrLater;
+        // store brace nesting level for template string fields, e.g. $"{{}}"
+        int braceLevel = 0;
 
         while (pos < text.Length)
         {
@@ -97,7 +103,18 @@ internal sealed class LexContext : ISubCompileContext
             {
                 pos = Identifiers.Parse(this, pos);
             }
-            else if (currChar == '$' || (currChar == '0' && nextChar == 'x'))
+            else if (currChar == '$')
+            {
+                if (nextChar == '"')
+                {
+                    pos = Strings.ParseTemplate(this, pos);
+                }
+                else
+                {
+                    pos = Numbers.ParseHex(this, pos, true);
+                }
+            }
+            else if (currChar == '0' && nextChar == 'x')
             {
                 pos = Numbers.ParseHex(this, pos, currChar == '$');
             }
@@ -136,9 +153,35 @@ internal sealed class LexContext : ISubCompileContext
                 if (!success)
                 {
                     CompileContext.PushError("Unrecognized token", this, pos);
+                    continue;
+                }
+
+                if (inTemplateString && Tokens[^1] is TokenSeparator sep)
+                {
+                    switch (sep.Kind)
+                    {
+                        case SeparatorKind.BlockOpen:
+                            braceLevel++;
+                            break;
+
+                        case SeparatorKind.BlockClose:
+                            if (braceLevel == 0)
+                            {
+                                return pos;
+                            }
+                            braceLevel--;
+                            break;
+                    }
                 }
             }
         }
+
+        if (inTemplateString)
+        {
+            // if not returned yet, we are at the end of the code
+            CompileContext.PushError("Template string field not closed", this, startPosition);
+        }
+        return pos;
     }
 
     /// <summary>

--- a/Underanalyzer/Compiler/Lexer/Strings.cs
+++ b/Underanalyzer/Compiler/Lexer/Strings.cs
@@ -60,161 +60,7 @@ internal static class Strings
                 break;
             }
 
-            // Error on newlines
-            if (c == '\n')
-            {
-                if (!newlineErroredAlready)
-                {
-                    newlineErroredAlready = true;
-                    context.CompileContext.PushError("Direct newline found in string (should use \"\\n\" instead, or a raw string literal)", context, startPosition);
-                }
-                pos++;
-                continue;
-            }
-
-            // Handle escape sequences
-            if (c == '\\' && pos + 1 < text.Length)
-            {
-                int escapeStartPos = pos;
-                char escapedChar = text[pos + 1];
-                pos += 2;
-
-                switch (escapedChar)
-                {
-                    case 'a':
-                        sb.Append('\a');
-                        break;
-                    case 'b':
-                        sb.Append('\b');
-                        break;
-                    case 'f':
-                        sb.Append('\f');
-                        break;
-                    case 'n':
-                        sb.Append('\n');
-                        break;
-                    case 'r':
-                        sb.Append('\r');
-                        break;
-                    case 't':
-                        sb.Append('\t');
-                        break;
-                    case 'v':
-                        sb.Append('\v');
-                        break;
-                    case 'u':
-                        {
-                            // Unicode character (as hex)
-                            int result = 0;
-                            int charsRead = 0;
-                            while (pos < text.Length && charsRead < 6)
-                            {
-                                // Read current character as 4 bits (one hex digit)
-                                int curr = HexCharToInt(text[pos]);
-                                if (curr == -1)
-                                {
-                                    // Not a valid hex digit, so stop here
-                                    break;
-                                }
-                                result = (result << 4) + curr;
-
-                                pos++;
-                                charsRead++;
-                            }
-
-                            // If at least one hex character was read, try to convert it all to a character
-                            if (charsRead != 0)
-                            {
-                                try
-                                {
-                                    sb.Append(char.ConvertFromUtf32(result));
-                                }
-                                catch (ArgumentOutOfRangeException)
-                                {
-                                    context.CompileContext.PushError("\\u character code not valid in string", context, escapeStartPos);
-                                }
-                            }
-                        }
-                        break;
-                    case 'x':
-                        {
-                            // Hex character
-                            int result = 0;
-                            int charsRead = 0;
-                            while (pos < text.Length && charsRead < 2)
-                            {
-                                // Read current character as 4 bits (one hex digit)
-                                int curr = HexCharToInt(text[pos]);
-                                if (curr == -1)
-                                {
-                                    // Not a valid hex digit, so stop here
-                                    break;
-                                }
-                                result = (result << 4) + curr;
-
-                                pos++;
-                                charsRead++;
-                            }
-
-                            // If exactly two characters were read, convert to a single character
-                            if (charsRead == 2)
-                            {
-                                sb.Append((char)result);
-                            }
-                            else
-                            {
-                                context.CompileContext.PushError("\\x character code needs exactly 2 hex digits", context, escapeStartPos);
-                            }
-                        }
-                        break;
-                    default:
-                        {
-                            if (escapedChar >= '0' && escapedChar <= '7')
-                            {
-                                // Octal character
-                                int result = 0;
-                                int charsRead = 0;
-                                pos--;
-                                while (pos < text.Length && charsRead < 3)
-                                {
-                                    // Read current character as octal
-                                    char octalChar = text[pos];
-                                    if (octalChar < '0' || octalChar > '7')
-                                    {
-                                        // Not a valid octal digit, so stop here
-                                        break;
-                                    }
-                                    result = (result * 8) + (octalChar - '0');
-
-                                    pos++;
-                                    charsRead++;
-                                }
-
-                                // If exactly three characters were read, convert to a single character
-                                if (charsRead == 3)
-                                {
-                                    sb.Append((char)result);
-                                }
-                                else
-                                {
-                                    context.CompileContext.PushError($"\\{escapedChar}?? octal value in string is missing valid octal characters", context, escapeStartPos);
-                                }
-                            }
-                            else
-                            {
-                                // Verbatim character
-                                sb.Append(escapedChar);
-                            }
-                        }
-                        break;
-                }
-
-                continue;
-            }
-
-            // All other characters are just normal text
-            sb.Append(c);
-            pos++;
+            pos = ParseChar(context, pos, sb, ref newlineErroredAlready);
         }
 
         // If at the end of the code, the string was not correctly closed
@@ -227,6 +73,233 @@ internal static class Strings
         context.Tokens.Add(new TokenString(context, startPosition, context.Text[startPosition..(pos + 1)], sb.ToString()));
 
         return pos + 1;
+    }
+
+    /// <summary>
+    /// Parses a template string literal from the given text position.
+    /// </summary>
+    public static int ParseTemplate(LexContext context, int startPosition)
+    {
+        ReadOnlySpan<char> text = context.Text;
+        int pos = startPosition + 2;
+        bool newlineErroredAlready = false;
+
+        context.Tokens.Add(new TokenTemplateStringStart(context, pos));
+        while (pos < text.Length)
+        {
+            char c = text[pos];
+
+            // Stop at closing quote
+            if (c == '"')
+            {
+                break;
+            }
+
+            // start of field
+            if (c == '{')
+            {
+                context.Tokens.Add(new TokenSeparator(context, pos, SeparatorKind.BlockOpen));
+                pos++;
+                pos = context.Tokenize(pos, true);
+                // '}' token is consumed by Tokenize
+                continue;
+            }
+
+            // any other character
+            int tokenStartPos = pos;
+            StringBuilder sb = new(32);
+            while (pos < text.Length && text[pos] is not ('"' or '{'))
+            {
+                pos = ParseChar(context, pos, sb, ref newlineErroredAlready);
+            }
+
+            // If at the end of the code, the string was not correctly closed
+            if (pos >= context.Text.Length)
+            {
+                context.CompileContext.PushError("String not closed", context, startPosition);
+                return pos;
+            }
+
+            // if we've read any characters:
+            if (pos != tokenStartPos)
+            {
+                context.Tokens.Add(new TokenTemplateStringMiddle(context, pos, context.Text[tokenStartPos..pos], sb.ToString()));
+            }
+        }
+
+        // If at the end of the code, the string was not correctly closed
+        if (pos >= context.Text.Length)
+        {
+            context.CompileContext.PushError("String not closed", context, startPosition);
+            return pos;
+        }
+        
+        context.Tokens.Add(new TokenTemplateStringEnd(context, pos));
+
+        return pos + 1;
+    }
+
+    private static int ParseChar(LexContext context, int pos, StringBuilder sb, ref bool newlineErroredAlready)
+    {
+        ReadOnlySpan<char> text = context.Text;
+        char c = text[pos];
+
+        // Error on newlines
+        if (c == '\n')
+        {
+            if (!newlineErroredAlready)
+            {
+                newlineErroredAlready = true;
+                context.CompileContext.PushError("Direct newline found in string (should use \"\\n\" instead, or a raw string literal)", context, pos);
+            }
+            pos++;
+            return pos;
+        }
+
+        if (c != '\\')
+        {
+            // All non-backslash characters are just normal text
+            sb.Append(c);
+            pos++;
+            return pos;
+        }
+
+        // Handle escape sequences
+        int escapeStartPos = pos;
+        char escapedChar = text[pos + 1];
+        pos += 2;
+
+        switch (escapedChar)
+        {
+            case 'a':
+                sb.Append('\a');
+                break;
+            case 'b':
+                sb.Append('\b');
+                break;
+            case 'f':
+                sb.Append('\f');
+                break;
+            case 'n':
+                sb.Append('\n');
+                break;
+            case 'r':
+                sb.Append('\r');
+                break;
+            case 't':
+                sb.Append('\t');
+                break;
+            case 'v':
+                sb.Append('\v');
+                break;
+            case 'u':
+                {
+                    // Unicode character (as hex)
+                    int result = 0;
+                    int charsRead = 0;
+                    while (pos < text.Length && charsRead < 6)
+                    {
+                        // Read current character as 4 bits (one hex digit)
+                        int curr = HexCharToInt(text[pos]);
+                        if (curr == -1)
+                        {
+                            // Not a valid hex digit, so stop here
+                            break;
+                        }
+                        result = (result << 4) + curr;
+
+                        pos++;
+                        charsRead++;
+                    }
+
+                    // If at least one hex character was read, try to convert it all to a character
+                    if (charsRead != 0)
+                    {
+                        try
+                        {
+                            sb.Append(char.ConvertFromUtf32(result));
+                        }
+                        catch (ArgumentOutOfRangeException)
+                        {
+                            context.CompileContext.PushError("\\u character code not valid in string", context, escapeStartPos);
+                        }
+                    }
+                }
+                break;
+            case 'x':
+                {
+                    // Hex character
+                    int result = 0;
+                    int charsRead = 0;
+                    while (pos < text.Length && charsRead < 2)
+                    {
+                        // Read current character as 4 bits (one hex digit)
+                        int curr = HexCharToInt(text[pos]);
+                        if (curr == -1)
+                        {
+                            // Not a valid hex digit, so stop here
+                            break;
+                        }
+                        result = (result << 4) + curr;
+
+                        pos++;
+                        charsRead++;
+                    }
+
+                    // If exactly two characters were read, convert to a single character
+                    if (charsRead == 2)
+                    {
+                        sb.Append((char)result);
+                    }
+                    else
+                    {
+                        context.CompileContext.PushError("\\x character code needs exactly 2 hex digits", context, escapeStartPos);
+                    }
+                }
+                break;
+            default:
+                {
+                    if (escapedChar >= '0' && escapedChar <= '7')
+                    {
+                        // Octal character
+                        int result = 0;
+                        int charsRead = 0;
+                        pos--;
+                        while (pos < text.Length && charsRead < 3)
+                        {
+                            // Read current character as octal
+                            char octalChar = text[pos];
+                            if (octalChar < '0' || octalChar > '7')
+                            {
+                                // Not a valid octal digit, so stop here
+                                break;
+                            }
+                            result = (result * 8) + (octalChar - '0');
+
+                            pos++;
+                            charsRead++;
+                        }
+
+                        // If exactly three characters were read, convert to a single character
+                        if (charsRead == 3)
+                        {
+                            sb.Append((char)result);
+                        }
+                        else
+                        {
+                            context.CompileContext.PushError($"\\{escapedChar}?? octal value in string is missing valid octal characters", context, escapeStartPos);
+                        }
+                    }
+                    else
+                    {
+                        // Verbatim character
+                        sb.Append(escapedChar);
+                    }
+                }
+                break;
+        }
+
+        return pos;
     }
 
     /// <summary>

--- a/Underanalyzer/Compiler/Lexer/Strings.cs
+++ b/Underanalyzer/Compiler/Lexer/Strings.cs
@@ -64,13 +64,13 @@ internal static class Strings
         }
 
         // If at the end of the code, the string was not correctly closed
-        if (pos >= context.Text.Length)
+        if (pos >= text.Length)
         {
             context.CompileContext.PushError("String not closed", context, startPosition);
             return pos;
         }
 
-        context.Tokens.Add(new TokenString(context, startPosition, context.Text[startPosition..(pos + 1)], sb.ToString()));
+        context.Tokens.Add(new TokenString(context, startPosition, text[startPosition..(pos + 1)].ToString(), sb.ToString()));
 
         return pos + 1;
     }
@@ -81,6 +81,7 @@ internal static class Strings
     public static int ParseTemplate(LexContext context, int startPosition)
     {
         ReadOnlySpan<char> text = context.Text;
+        StringBuilder sb = new(64);
         int pos = startPosition + 2;
         bool newlineErroredAlready = false;
 
@@ -95,7 +96,7 @@ internal static class Strings
                 break;
             }
 
-            // start of field
+            // Start of field
             if (c == '{')
             {
                 context.Tokens.Add(new TokenSeparator(context, pos, SeparatorKind.BlockOpen));
@@ -105,30 +106,30 @@ internal static class Strings
                 continue;
             }
 
-            // any other character
+            // Any other character
             int tokenStartPos = pos;
-            StringBuilder sb = new(32);
+            sb.Clear();
             while (pos < text.Length && text[pos] is not ('"' or '{'))
             {
                 pos = ParseChar(context, pos, sb, ref newlineErroredAlready);
             }
 
             // If at the end of the code, the string was not correctly closed
-            if (pos >= context.Text.Length)
+            if (pos >= text.Length)
             {
                 context.CompileContext.PushError("String not closed", context, startPosition);
                 return pos;
             }
 
-            // if we've read any characters:
+            // If we've read any characters, make a token for that section of the string
             if (pos != tokenStartPos)
             {
-                context.Tokens.Add(new TokenTemplateStringMiddle(context, pos, context.Text[tokenStartPos..pos], sb.ToString()));
+                context.Tokens.Add(new TokenTemplateStringMiddle(context, pos, text[tokenStartPos..pos].ToString(), sb.ToString()));
             }
         }
 
         // If at the end of the code, the string was not correctly closed
-        if (pos >= context.Text.Length)
+        if (pos >= text.Length)
         {
             context.CompileContext.PushError("String not closed", context, startPosition);
             return pos;
@@ -138,7 +139,10 @@ internal static class Strings
 
         return pos + 1;
     }
-
+    
+    /// <summary>
+    /// Parses a single character within a string, appending it to the supplied StringBuilder, and returning the new text position.
+    /// </summary>
     private static int ParseChar(LexContext context, int pos, StringBuilder sb, ref bool newlineErroredAlready)
     {
         ReadOnlySpan<char> text = context.Text;
@@ -156,7 +160,7 @@ internal static class Strings
             return pos;
         }
 
-        if (c != '\\')
+        if (c != '\\' || (pos + 1) >= text.Length)
         {
             // All non-backslash characters are just normal text
             sb.Append(c);

--- a/Underanalyzer/Compiler/Lexer/Token.cs
+++ b/Underanalyzer/Compiler/Lexer/Token.cs
@@ -356,6 +356,40 @@ internal sealed record TokenString(LexContext Context, int TextPosition, string 
 }
 
 /// <summary>
+/// Token representing the starting quote of a template string in code.
+/// </summary>
+internal sealed record TokenTemplateStringStart(LexContext Context, int TextPosition) : IToken
+{
+    public override string ToString()
+    {
+        return "$\"";
+    }
+}
+
+/// <summary>
+/// Token representing the ending quote of a template string in code.
+/// </summary>
+internal sealed record TokenTemplateStringEnd(LexContext Context, int TextPosition) : IToken
+{
+    public override string ToString()
+    {
+        return "\"";
+    }
+}
+
+/// <summary>
+/// Token representing content in a template string in code.
+/// </summary>
+internal sealed record TokenTemplateStringMiddle(LexContext Context, int TextPosition, string Text, string Value) : IToken
+{
+    public override string ToString()
+    {
+        return Text;
+    }
+}
+
+
+/// <summary>
 /// Token representing a simple function call in code.
 /// </summary>
 /// <param name="Text">Verbatim text used for the function identifier.</param>

--- a/Underanalyzer/Compiler/Nodes/FunctionCallNode.cs
+++ b/Underanalyzer/Compiler/Nodes/FunctionCallNode.cs
@@ -4,7 +4,6 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-using System;
 using System.Collections.Generic;
 using Underanalyzer.Compiler.Bytecode;
 using Underanalyzer.Compiler.Lexer;

--- a/Underanalyzer/Compiler/Nodes/SimpleFunctionCallNode.cs
+++ b/Underanalyzer/Compiler/Nodes/SimpleFunctionCallNode.cs
@@ -120,44 +120,53 @@ internal sealed class SimpleFunctionCallNode : IMaybeStatementASTNode
     /// Parses a template string from the given context's current position, and returns
     /// a corresponding function call node for that string.
     /// </summary>
-    public static SimpleFunctionCallNode ParseTemplateString(ParseContext context)
+    public static IASTNode ParseTemplateString(ParseContext context)
     {
         var startToken = context.Tokens[context.Position - 1];
 
-        // placeholder string node, to be replaced with format string later
-        List<IASTNode> arguments = [new StringNode("", null)];
+        // Placeholder string node, to be replaced with format string later
+        List<IASTNode> arguments = new(4)
+        {
+            new StringNode("", null)
+        };
 
+        // For newer GameMaker versions, use modern template string function; otherwise, use regular string function
+        string templateStringFunction = context.CompileContext.GameContext.UsingModernTemplateStrings ?
+            VMConstants.ModernTemplateStringFunction : VMConstants.TemplateStringFunction;
         SimpleFunctionCallNode result = new(
-            VMConstants.TemplateStringFunction, 
-            context.CompileContext.GameContext.Builtins.LookupBuiltinFunction(VMConstants.TemplateStringFunction), 
+            templateStringFunction, 
+            context.CompileContext.GameContext.Builtins.LookupBuiltinFunction(templateStringFunction), 
             arguments
         );
 
+        // Build out the format string, segment by segment
         int fieldIndex = 0;
-        StringBuilder formatSb = new();
+        StringBuilder formatSb = new(64);
         while (!context.EndOfCode && context.CurrentToken is not TokenTemplateStringEnd)
         {
-            if (context.CurrentToken is TokenTemplateStringMiddle { Value: var value })
+            // For regular text segments, just append their contents directly
+            if (context.CurrentToken is TokenTemplateStringMiddle { Value: string value })
             {
                 formatSb.Append(value);
                 context.Position++;
                 continue;
             }
 
+            // For fields, parse expression and append placeholder index
             if (context.IsCurrentToken(SeparatorKind.BlockOpen))
             {
                 context.Position++;
 
-                // parse field
+                // Parse field
                 if (Expressions.ParseExpression(context) is IASTNode expr)
                 {
                     arguments.Add(expr);
-                    formatSb.Append($"{{{fieldIndex}}}"); // {0}
+                    formatSb.Append($"{{{fieldIndex}}}"); // e.g. {0}
                     fieldIndex++;
                 }
                 else
                 {
-                    // failed to parse expression; stop parsing template string
+                    // Failed to parse expression; stop parsing template string
                     break;
                 }
 
@@ -166,13 +175,21 @@ internal sealed class SimpleFunctionCallNode : IMaybeStatementASTNode
             }
         }
 
+        // Replace first argument with final format string
         arguments[0] = new StringNode(formatSb.ToString(), startToken);
 
+        // Move past the end of the string, or error if it wasn't found
         if (context.EndOfCode)
         {
             context.CompileContext.PushError($"Unexpected end of code (expected '\"')");
         }
         context.Position++;
+
+        // If no arguments were actually used, we don't need to create a function at all, actually
+        if (fieldIndex == 0)
+        {
+            return arguments[0];
+        }
 
         return result;
     }

--- a/Underanalyzer/Compiler/Nodes/SimpleFunctionCallNode.cs
+++ b/Underanalyzer/Compiler/Nodes/SimpleFunctionCallNode.cs
@@ -116,6 +116,66 @@ internal sealed class SimpleFunctionCallNode : IMaybeStatementASTNode
 
         return result;
     }
+    /// <summary>
+    /// Parses a template string from the given context's current position, and returns
+    /// a corresponding function call node for that string.
+    /// </summary>
+    public static SimpleFunctionCallNode ParseTemplateString(ParseContext context)
+    {
+        var startToken = context.Tokens[context.Position - 1];
+
+        // placeholder string node, to be replaced with format string later
+        List<IASTNode> arguments = [new StringNode("", null)];
+
+        SimpleFunctionCallNode result = new(
+            VMConstants.TemplateStringFunction, 
+            context.CompileContext.GameContext.Builtins.LookupBuiltinFunction(VMConstants.TemplateStringFunction), 
+            arguments
+        );
+
+        int fieldIndex = 0;
+        StringBuilder formatSb = new();
+        while (!context.EndOfCode && context.CurrentToken is not TokenTemplateStringEnd)
+        {
+            if (context.CurrentToken is TokenTemplateStringMiddle { Value: var value })
+            {
+                formatSb.Append(value);
+                context.Position++;
+                continue;
+            }
+
+            if (context.IsCurrentToken(SeparatorKind.BlockOpen))
+            {
+                context.Position++;
+
+                // parse field
+                if (Expressions.ParseExpression(context) is IASTNode expr)
+                {
+                    arguments.Add(expr);
+                    formatSb.Append($"{{{fieldIndex}}}"); // {0}
+                    fieldIndex++;
+                }
+                else
+                {
+                    // failed to parse expression; stop parsing template string
+                    break;
+                }
+
+                context.EnsureToken(SeparatorKind.BlockClose);
+                continue;
+            }
+        }
+
+        arguments[0] = new StringNode(formatSb.ToString(), startToken);
+
+        if (context.EndOfCode)
+        {
+            context.CompileContext.PushError($"Unexpected end of code (expected '\"')");
+        }
+        context.Position++;
+
+        return result;
+    }
 
     /// <inheritdoc/>
     public IASTNode PostProcess(ParseContext context)

--- a/Underanalyzer/Compiler/Parser/Expressions.cs
+++ b/Underanalyzer/Compiler/Parser/Expressions.cs
@@ -729,6 +729,14 @@ internal static class Expressions
             case TokenString tokenString:
                 context.Position++;
                 return new StringNode(tokenString);
+            case TokenTemplateStringStart:
+                context.Position++;
+                if (context.CompileContext.GameContext.UsingTemplateStrings)
+                {
+                    return SimpleFunctionCallNode.ParseTemplateString(context);
+                }
+                context.CompileContext.PushError("Cannot use template strings in this game context", token);
+                return null;
             case TokenBoolean tokenBoolean:
                 context.Position++;
                 return new BooleanNode(tokenBoolean);

--- a/Underanalyzer/Compiler/Parser/Expressions.cs
+++ b/Underanalyzer/Compiler/Parser/Expressions.cs
@@ -735,7 +735,7 @@ internal static class Expressions
                 {
                     return SimpleFunctionCallNode.ParseTemplateString(context);
                 }
-                context.CompileContext.PushError("Cannot use template strings in this game context", token);
+                context.CompileContext.PushError("Cannot use template strings in this GameMaker version", token);
                 return null;
             case TokenBoolean tokenBoolean:
                 context.Position++;

--- a/Underanalyzer/Compiler/Parser/ParseContext.cs
+++ b/Underanalyzer/Compiler/Parser/ParseContext.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using Underanalyzer.Compiler.Lexer;
 using Underanalyzer.Compiler.Nodes;
+using Underanalyzer.Decompiler.AST;
 
 namespace Underanalyzer.Compiler.Parser;
 
@@ -45,9 +46,14 @@ internal sealed class ParseContext : ISubCompileContext
     public HashSet<string>? ParseGlobalFunctions { get; } = null;
 
     /// <summary>
-    /// List of tokens to be parsed by this context.
-    /// </summary>
+    /// The position of the current token being parsed by this context. 
+    /// /// </summary>
     public int Position { get; set; } = 0;
+
+    /// <summary>
+    /// The current token being parsed by this context.
+    /// </summary>
+    public IToken CurrentToken => Tokens[Position];
 
     /// <summary>
     /// True if reached the end of code; false otherwise.
@@ -113,7 +119,7 @@ internal sealed class ParseContext : ISubCompileContext
     /// </summary>
     public void Parse()
     {
-        Root = BlockNode.ParseRoot(this);
+        Root = Nodes.BlockNode.ParseRoot(this);
     }
 
     /// <summary>

--- a/Underanalyzer/Compiler/Parser/ParseContext.cs
+++ b/Underanalyzer/Compiler/Parser/ParseContext.cs
@@ -7,7 +7,6 @@
 using System.Collections.Generic;
 using Underanalyzer.Compiler.Lexer;
 using Underanalyzer.Compiler.Nodes;
-using Underanalyzer.Decompiler.AST;
 
 namespace Underanalyzer.Compiler.Parser;
 
@@ -119,7 +118,7 @@ internal sealed class ParseContext : ISubCompileContext
     /// </summary>
     public void Parse()
     {
-        Root = Nodes.BlockNode.ParseRoot(this);
+        Root = BlockNode.ParseRoot(this);
     }
 
     /// <summary>

--- a/Underanalyzer/Decompiler/AST/Nodes/FunctionCallNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/FunctionCallNode.cs
@@ -4,6 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
+using System;
 using System.Collections.Generic;
 using Underanalyzer.Decompiler.GameSpecific;
 
@@ -61,7 +62,7 @@ public class FunctionCallNode(IGMFunction function, List<IExpressionNode> argume
             Arguments[i] = Arguments[i].Clean(cleaner);
         }
 
-        // Handle special instance types
+        // Handle special instance types and template strings
         switch (Function.Name.Content)
         {
             case VMConstants.SelfFunction:
@@ -87,6 +88,8 @@ public class FunctionCallNode(IGMFunction function, List<IExpressionNode> argume
                 Arguments[0].Duplicated = true;
                 Arguments[0].StackType = StackType;
                 return Arguments[0];
+            case VMConstants.TemplateStringFunction:
+                return CleanupTemplateString(cleaner);
         }
 
         return CleanupMacroTypes(cleaner);
@@ -172,6 +175,72 @@ public class FunctionCallNode(IGMFunction function, List<IExpressionNode> argume
 
         // No resolution found
         return this;
+    }
+
+    private IExpressionNode CleanupTemplateString(ASTCleaner cleaner)
+    {
+        if (!cleaner.Context.Settings.CleanupTemplateStrings)
+        {
+            return this;
+        }
+
+        // make sure format is valid, fall back to function call and return as is otherwise
+
+        if (Arguments is not [StringNode { Value: { Content: string format } formatRef }, ..])
+        {
+            return this;
+        }
+
+        // for each field, whether or not a placeholder exists
+        bool[] fieldsSeen = new bool[Arguments.Count - 1];
+        for (int i = 0; i < format.Length; i++)
+        {
+            if (format[i] != '{')
+            {
+                continue;
+            }
+
+            // parse a placeholder
+
+            i++;
+            bool valid = i < format.Length && format[i] != '}';
+            int index = 0;
+            while (i < format.Length && format[i] != '}')
+            {
+                if (format[i] < '0' || format[i] > '9')
+                {
+                    valid = false;
+                }
+                if (valid)
+                {
+                    index = index * 10 + (format[i] - '0');
+                }
+                i++;
+            }
+            if (!valid || i >= format.Length)
+            {
+                continue;
+            }
+
+            if (index >= fieldsSeen.Length || fieldsSeen[index])
+            {
+                // out of range or duplicate
+                return this;
+            }
+            fieldsSeen[index] = true;
+        }
+
+        // make sure all fields have corresponding placeholders
+        foreach (var seen in fieldsSeen)
+        {
+            if (!seen)
+            {
+                return this;
+            }
+        }
+
+        Arguments.RemoveAt(0);
+        return new TemplateStringNode(formatRef, Arguments);
     }
 
     /// <inheritdoc/>

--- a/Underanalyzer/Decompiler/AST/Nodes/FunctionCallNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/FunctionCallNode.cs
@@ -89,7 +89,23 @@ public class FunctionCallNode(IGMFunction function, List<IExpressionNode> argume
                 Arguments[0].StackType = StackType;
                 return Arguments[0];
             case VMConstants.TemplateStringFunction:
-                return CleanupTemplateString(cleaner);
+                {
+                    IGameContext context = cleaner.Context.GameContext;
+                    if (context.UsingTemplateStrings && !context.UsingModernTemplateStrings)
+                    {
+                        return CleanupTemplateString(cleaner, false);
+                    }
+                    break;
+                }
+            case VMConstants.ModernTemplateStringFunction:
+                {
+                    IGameContext context = cleaner.Context.GameContext;
+                    if (context.UsingTemplateStrings && context.UsingModernTemplateStrings)
+                    {
+                        return CleanupTemplateString(cleaner, true);
+                    }
+                    break;
+                }
         }
 
         return CleanupMacroTypes(cleaner);
@@ -177,68 +193,78 @@ public class FunctionCallNode(IGMFunction function, List<IExpressionNode> argume
         return this;
     }
 
-    private IExpressionNode CleanupTemplateString(ASTCleaner cleaner)
+    private IExpressionNode CleanupTemplateString(ASTCleaner cleaner, bool isModern)
     {
+        // Don't attempt cleanup if not enabled
         if (!cleaner.Context.Settings.CleanupTemplateStrings)
         {
             return this;
         }
 
-        // make sure format is valid, fall back to function call and return as is otherwise
-
+        // Make sure format is valid; fall back to function call and return as-is, otherwise
         if (Arguments is not [StringNode { Value: { Content: string format } formatRef }, ..])
+        {
+            return this;
+        }
+        if (Arguments.Count < 2)
         {
             return this;
         }
 
         // for each field, whether or not a placeholder exists
-        bool[] fieldsSeen = new bool[Arguments.Count - 1];
+        int nextExpectedFieldIndex = 0;
+        int maxExpectedFieldIndex = Arguments.Count - 2;
         for (int i = 0; i < format.Length; i++)
         {
+            // Skip non-placeholder starting characters
             if (format[i] != '{')
             {
                 continue;
             }
 
-            // parse a placeholder
-
-            i++;
-            bool valid = i < format.Length && format[i] != '}';
-            int index = 0;
-            while (i < format.Length && format[i] != '}')
+            // If the next character is the same, it can be treated as an escape on non-modern versions, and
+            // we probably just want to bail to preserve behavior... (e.g. if ported to other GM versions)
+            if (!isModern && (i + 1) < format.Length && format[i + 1] == '{')
             {
-                if (format[i] < '0' || format[i] > '9')
-                {
-                    valid = false;
-                }
-                if (valid)
-                {
-                    index = index * 10 + (format[i] - '0');
-                }
-                i++;
+                return this;
             }
-            if (!valid || i >= format.Length)
+
+            // Parse the placeholder (may not necessarily be valid)
+            int startIndex = i + 1;
+            int j = startIndex;
+            while (j < format.Length && format[j] != '}')
+            {
+                j++;
+            }
+            if (j >= format.Length || j == startIndex)
             {
                 continue;
             }
-
-            if (index >= fieldsSeen.Length || fieldsSeen[index])
+            ReadOnlySpan<char> placeholderNumberText = format.AsSpan()[startIndex..j];
+            if (!int.TryParse(placeholderNumberText, out int fieldIndex))
             {
-                // out of range or duplicate
+                continue;
+            }
+            if (fieldIndex < 0 || fieldIndex > maxExpectedFieldIndex || fieldIndex != nextExpectedFieldIndex)
+            {
+                // Totally invalid or unexpected field index... bail!
                 return this;
             }
-            fieldsSeen[index] = true;
+
+            // Move on to next field - should be in linear order for regular interpolated strings
+            nextExpectedFieldIndex++;
+
+            // Advance to the end of the placeholder
+            i = j;
         }
 
-        // make sure all fields have corresponding placeholders
-        foreach (var seen in fieldsSeen)
+        // If we didn't use exactly the number of expected indices, bail!
+        if (nextExpectedFieldIndex != (maxExpectedFieldIndex + 1))
         {
-            if (!seen)
-            {
-                return this;
-            }
+            return this;
         }
 
+        // No checks failed, and this seems to be a valid (possible) template string!
         Arguments.RemoveAt(0);
         return new TemplateStringNode(formatRef, Arguments);
     }

--- a/Underanalyzer/Decompiler/AST/Nodes/FunctionCallNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/FunctionCallNode.cs
@@ -232,11 +232,17 @@ public class FunctionCallNode(IGMFunction function, List<IExpressionNode> argume
             // Parse the placeholder (may not necessarily be valid)
             int startIndex = i + 1;
             int j = startIndex;
+            bool invalidCharacter = false;
             while (j < format.Length && format[j] != '}')
             {
+                if (format[j] < '0' || format[j] > '9')
+                {
+                    invalidCharacter = true;
+                    break;
+                }
                 j++;
             }
-            if (j >= format.Length || j == startIndex)
+            if (invalidCharacter || j >= format.Length || j == startIndex)
             {
                 continue;
             }

--- a/Underanalyzer/Decompiler/AST/Nodes/StringNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/StringNode.cs
@@ -53,41 +53,26 @@ public class StringNode(IGMString value) : IConstantNode<IGMString>, IConditiona
         printer.Write('"');
         foreach (char c in content)
         {
-            switch (c)
-            {
-                case '\n':
-                    printer.Write("\\n");
-                    break;
-                case '\r':
-                    printer.Write("\\r");
-                    break;
-                case '\b':
-                    printer.Write("\\b");
-                    break;
-                case '\f':
-                    printer.Write("\\f");
-                    break;
-                case '\t':
-                    printer.Write("\\t");
-                    break;
-                case '\v':
-                    printer.Write("\\v");
-                    break;
-                case '\a':
-                    printer.Write("\\a");
-                    break;
-                case '\\':
-                    printer.Write("\\\\");
-                    break;
-                case '\"':
-                    printer.Write("\\\"");
-                    break;
-                default:
-                    printer.Write(c);
-                    break;
-            }
+            printer.Write(EscapeChar(c));
         }
         printer.Write('"');
+    }
+
+    public static string EscapeChar(char c)
+    {
+        return c switch
+        {
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\b' => "\\b",
+            '\f' => "\\f",
+            '\t' => "\\t",
+            '\v' => "\\v",
+            '\a' => "\\a",
+            '\\' => "\\\\",
+            '"' => "\\\"",
+            _ => c.ToString(),
+        };
     }
 
     /// <inheritdoc/>

--- a/Underanalyzer/Decompiler/AST/Nodes/TemplateStringNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/TemplateStringNode.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Underanalyzer.Decompiler.GameSpecific;
 
 namespace Underanalyzer.Decompiler.AST;
@@ -141,6 +140,10 @@ public class TemplateStringNode(IGMString format, List<IExpressionNode> fields)
 
     public IExpressionNode? ResolveMacroType(ASTCleaner cleaner, IMacroType type)
     {
-        throw new System.NotImplementedException();
+        if (type is IMacroTypeConditional conditional)
+        {
+            return conditional.Resolve(cleaner, this);
+        }
+        return null;
     }
 }

--- a/Underanalyzer/Decompiler/AST/Nodes/TemplateStringNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/TemplateStringNode.cs
@@ -4,6 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Underanalyzer.Decompiler.GameSpecific;
@@ -68,62 +69,59 @@ public class TemplateStringNode(IGMString format, List<IExpressionNode> fields)
         printer.Write("$\"");
 
         string format = Format.Content;
-        // for each field, whether or not a placeholder exists
-        bool[] fieldsSeen = new bool[Fields.Count];
+        int nextExpectedFieldIndex = 0;
+        int maxExpectedFieldIndex = Fields.Count - 1;
         for (int i = 0; i < format.Length; i++)
         {
+            // Print non-placeholder starting characters normally
             if (format[i] != '{')
             {
                 printer.Write(StringNode.EscapeChar(format[i]));
                 continue;
             }
 
-            // parse a placeholder
-
-            i++;
-            bool valid = i < format.Length && format[i] != '}';
-            int index = 0;
-            StringBuilder placeholderSb = new("\\{"); // also parse as text in case it's invalid
-            while (i < format.Length && format[i] != '}')
+            // Parse the placeholder (may not necessarily be valid)
+            int startIndex = i + 1;
+            int j = startIndex;
+            while (j < format.Length && format[j] != '}')
             {
-                placeholderSb.Append(StringNode.EscapeChar(format[i]));
-                if (format[i] < '0' || format[i] > '9')
-                {
-                    valid = false;
-                }
-                if (valid)
-                {
-                    index = index * 10 + (format[i] - '0');
-                }
-                i++;
+                j++;
             }
-            if (i >= format.Length)
+            if (j >= format.Length || j == startIndex)
             {
-                printer.Write(placeholderSb.ToString());
+                // Invalid - escape the character!
+                printer.Write("\\{");
                 continue;
             }
-            if (!valid)
+            ReadOnlySpan<char> placeholderNumberText = format.AsSpan()[startIndex..j];
+            if (!int.TryParse(placeholderNumberText, out int fieldIndex))
             {
-                printer.Write(placeholderSb.ToString());
-                printer.Write("\\}");
+                // Invalid - escape the character!
+                printer.Write("\\{");
                 continue;
             }
-
-            if (index >= fieldsSeen.Length)
+            if (fieldIndex < 0 || fieldIndex > maxExpectedFieldIndex || fieldIndex != nextExpectedFieldIndex)
             {
-                // this should have been taken care of in the cleanup step...
-                throw new DecompilerException("Out-of-range placeholder in template string format");
+                // Totally invalid or unexpected field index... this should have been handled already!
+                throw new DecompilerException("Unexpected string template placeholder index");
             }
-            if (fieldsSeen[index])
-            {
-                // this too
-                throw new DecompilerException("Duplicate placeholder in template string format");
-            }
-            fieldsSeen[index] = true;
 
+            // Print the actual field
             printer.Write('{');
-            Fields[index].Print(printer);
+            Fields[fieldIndex].Print(printer);
             printer.Write('}');
+
+            // Move on to next field - should be in linear order for regular interpolated strings
+            nextExpectedFieldIndex++;
+
+            // Advance to the end of the placeholder
+            i = j;
+        }
+
+        // If we didn't use exactly the number of expected indices, that's a problem... this should've been handled already!
+        if (nextExpectedFieldIndex != (maxExpectedFieldIndex + 1))
+        {
+            throw new DecompilerException("Unexpected final string template placeholder index");
         }
 
         printer.Write('"');

--- a/Underanalyzer/Decompiler/AST/Nodes/TemplateStringNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/TemplateStringNode.cs
@@ -1,0 +1,148 @@
+/*
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+
+using System.Collections.Generic;
+using System.Text;
+using Underanalyzer.Decompiler.GameSpecific;
+
+namespace Underanalyzer.Decompiler.AST;
+
+/// <summary>
+/// Represents a template string in the AST.
+/// </summary>
+public class TemplateStringNode(IGMString format, List<IExpressionNode> fields)
+    : IExpressionNode, IConditionalValueNode
+{
+    /// <summary>
+    /// The underlying format string.
+    /// </summary>
+    public IGMString Format { get; private set; } = format;
+
+    /// <summary>
+    /// The values to be inserted in the format string.
+    /// </summary>
+    public List<IExpressionNode> Fields { get; private set; } = fields;
+
+    /// <inheritdoc/>
+    public bool Duplicated { get; set; }
+
+    /// <inheritdoc/>
+    public bool Group { get; set; } = false;
+
+    /// <inheritdoc/>
+    public IGMInstruction.DataType StackType { get; set; } = IGMInstruction.DataType.Variable;
+
+    public string ConditionalTypeName => "TemplateString";
+
+    public string ConditionalValue => Format.Content;
+
+    /// <inheritdoc/>
+    public IExpressionNode Clean(ASTCleaner cleaner)
+    {
+        for (int i = 0; i < Fields.Count; i++)
+        {
+            Fields[i] = Fields[i].Clean(cleaner);
+        }
+        return this;
+    }
+
+    public IEnumerable<IBaseASTNode> EnumerateChildren()
+    {
+        return Fields;
+    }
+
+    public IExpressionNode PostClean(ASTCleaner cleaner)
+    {
+        for (int i = 0; i < Fields.Count; i++)
+        {
+            Fields[i] = Fields[i].PostClean(cleaner);
+        }
+        return this;
+    }
+
+    public void Print(ASTPrinter printer)
+    {
+        printer.Write("$\"");
+
+        string format = Format.Content;
+        // for each field, whether or not a placeholder exists
+        bool[] fieldsSeen = new bool[Fields.Count];
+        for (int i = 0; i < format.Length; i++)
+        {
+            if (format[i] != '{')
+            {
+                printer.Write(StringNode.EscapeChar(format[i]));
+                continue;
+            }
+
+            // parse a placeholder
+
+            i++;
+            bool valid = i < format.Length && format[i] != '}';
+            int index = 0;
+            StringBuilder placeholderSb = new("\\{"); // also parse as text in case it's invalid
+            while (i < format.Length && format[i] != '}')
+            {
+                placeholderSb.Append(StringNode.EscapeChar(format[i]));
+                if (format[i] < '0' || format[i] > '9')
+                {
+                    valid = false;
+                }
+                if (valid)
+                {
+                    index = index * 10 + (format[i] - '0');
+                }
+                i++;
+            }
+            if (i >= format.Length)
+            {
+                printer.Write(placeholderSb.ToString());
+                continue;
+            }
+            if (!valid)
+            {
+                printer.Write(placeholderSb.ToString());
+                printer.Write("\\}");
+                continue;
+            }
+
+            if (index >= fieldsSeen.Length)
+            {
+                // this should have been taken care of in the cleanup step...
+                throw new DecompilerException("Out-of-range placeholder in template string format");
+            }
+            if (fieldsSeen[index])
+            {
+                // this too
+                throw new DecompilerException("Duplicate placeholder in template string format");
+            }
+            fieldsSeen[index] = true;
+
+            printer.Write('{');
+            Fields[index].Print(printer);
+            printer.Write('}');
+        }
+
+        printer.Write('"');
+    }
+
+    public bool RequiresMultipleLines(ASTPrinter printer)
+    {
+        foreach (var field in Fields)
+        {
+            if (field.RequiresMultipleLines(printer))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public IExpressionNode? ResolveMacroType(ASTCleaner cleaner, IMacroType type)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/Underanalyzer/Decompiler/AST/Nodes/TemplateStringNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/TemplateStringNode.cs
@@ -82,20 +82,26 @@ public class TemplateStringNode(IGMString format, List<IExpressionNode> fields)
             // Parse the placeholder (may not necessarily be valid)
             int startIndex = i + 1;
             int j = startIndex;
+            bool invalidCharacter = false;
             while (j < format.Length && format[j] != '}')
             {
+                if (format[j] < '0' || format[j] > '9')
+                {
+                    invalidCharacter = true;
+                    break;
+                }
                 j++;
             }
-            if (j >= format.Length || j == startIndex)
+            if (invalidCharacter || j >= format.Length || j == startIndex)
             {
-                // Invalid - escape the character!
+                // Invalid - escape the starting character!
                 printer.Write("\\{");
                 continue;
             }
             ReadOnlySpan<char> placeholderNumberText = format.AsSpan()[startIndex..j];
             if (!int.TryParse(placeholderNumberText, out int fieldIndex))
             {
-                // Invalid - escape the character!
+                // Invalid - escape the starting character!
                 printer.Write("\\{");
                 continue;
             }

--- a/Underanalyzer/Decompiler/DecompileSettings.cs
+++ b/Underanalyzer/Decompiler/DecompileSettings.cs
@@ -121,6 +121,11 @@ public interface IDecompileSettings
     public bool CleanupLocalVarDeclarations { get; }
 
     /// <summary>
+    /// If true, the decompiler will make an attempt to rewrite calls to <tt>@@string@@</tt> as template strings.
+    /// </summary>
+    public bool CleanupTemplateStrings { get; }
+
+    /// <summary>
     /// If true, enum values that are detected in a code entry (including any unknown ones) will 
     /// be given declarations at the top of the code.
     /// </summary>
@@ -184,6 +189,7 @@ public class DecompileSettings : IDecompileSettings
     public bool CleanupDefaultArgumentValues { get; set; } = true;
     public bool CleanupBuiltinArrayVariables { get; set; } = true;
     public bool CleanupLocalVarDeclarations { get; set; } = true;
+    public bool CleanupTemplateStrings { get; set; } = true;
     public bool CreateEnumDeclarations { get; set; } = true;
     public string UnknownEnumName { get; set; } = "UnknownEnum";
     public string UnknownEnumValuePattern { get; set; } = "Value_{0}";

--- a/Underanalyzer/Decompiler/DecompileSettings.cs
+++ b/Underanalyzer/Decompiler/DecompileSettings.cs
@@ -121,7 +121,8 @@ public interface IDecompileSettings
     public bool CleanupLocalVarDeclarations { get; }
 
     /// <summary>
-    /// If true, the decompiler will make an attempt to rewrite calls to <tt>@@string@@</tt> as template strings.
+    /// If true, the decompiler will make an attempt to rewrite calls to <tt>string</tt>/<tt>@@string@@</tt> as template strings,
+    /// as it pertains to the game context and its GameMaker version.
     /// </summary>
     public bool CleanupTemplateStrings { get; }
 

--- a/Underanalyzer/IGameContext.cs
+++ b/Underanalyzer/IGameContext.cs
@@ -208,9 +208,17 @@ public interface IGameContext
     /// <see langword="true"/> if the game uses template strings; <see langword="false"/> otherwise.
     /// </summary>
     /// <remarks>
-    /// Currently only supports the new code generation via <tt>@@string@@</tt>, introduced in GameMaker 2024.14.
+    /// This alone signifies support added in GameMaker 2023.4. Modern code generation introduced in 2024.14 is different.
     /// </remarks>
     public bool UsingTemplateStrings { get; }
+
+    /// <summary>
+    /// <see langword="true"/> if the game uses the modern code generation for template strings; <see langword="false"/> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// This changes the code generation for template strings to match what is observed in GameMaker 2024.14 and above.
+    /// </remarks>
+    public bool UsingModernTemplateStrings { get; }
 
     /// <summary>
     /// Interface for getting global functions.

--- a/Underanalyzer/IGameContext.cs
+++ b/Underanalyzer/IGameContext.cs
@@ -205,6 +205,14 @@ public interface IGameContext
     public bool UsingNewChainedFunctionArgumentOrder { get; }
 
     /// <summary>
+    /// <see langword="true"/> if the game uses template strings; <see langword="false"/> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// Currently only supports the new code generation via <tt>@@string@@</tt>, introduced in GameMaker 2024.14.
+    /// </remarks>
+    public bool UsingTemplateStrings { get; }
+
+    /// <summary>
     /// Interface for getting global functions.
     /// Can be custom, or can use the provided implementation of <see cref="Decompiler.GlobalFunctions"/>.
     /// This should not be modified during decompilation.

--- a/Underanalyzer/Mock/BuiltinsMock.cs
+++ b/Underanalyzer/Mock/BuiltinsMock.cs
@@ -55,6 +55,7 @@ public class BuiltinsMock : IBuiltins
         { VMConstants.TryUnhookFunction, new(VMConstants.TryUnhookFunction, 0, 0) },
         { VMConstants.FinishCatchFunction, new(VMConstants.FinishCatchFunction, 0, 0) },
         { VMConstants.FinishFinallyFunction, new(VMConstants.FinishFinallyFunction, 0, 0) },
+        { VMConstants.TemplateStringFunction, new(VMConstants.TemplateStringFunction, 1, int.MaxValue) },
     };
 
     /// <summary>

--- a/Underanalyzer/Mock/BuiltinsMock.cs
+++ b/Underanalyzer/Mock/BuiltinsMock.cs
@@ -33,7 +33,6 @@ public class BuiltinsMock : IBuiltins
     public Dictionary<string, BuiltinFunctionMock> BuiltinFunctions = new()
     {
         { "test_builtin_function", new("test_builtin_function", 0, int.MaxValue) },
-        { "string", new("string", 1, 1) },
         { "real", new("real", 1, 1) },
         { "ord", new("ord", 1, 1) },
         { "script_execute", new("script_execute", 1, int.MaxValue) },
@@ -56,6 +55,7 @@ public class BuiltinsMock : IBuiltins
         { VMConstants.FinishCatchFunction, new(VMConstants.FinishCatchFunction, 0, 0) },
         { VMConstants.FinishFinallyFunction, new(VMConstants.FinishFinallyFunction, 0, 0) },
         { VMConstants.TemplateStringFunction, new(VMConstants.TemplateStringFunction, 1, int.MaxValue) },
+        { VMConstants.ModernTemplateStringFunction, new(VMConstants.ModernTemplateStringFunction, 1, int.MaxValue) },
     };
 
     /// <summary>

--- a/Underanalyzer/Mock/GameContextMock.cs
+++ b/Underanalyzer/Mock/GameContextMock.cs
@@ -70,6 +70,8 @@ public class GameContextMock : IGameContext
     /// <inheritdoc/>
     public bool UsingNewChainedFunctionArgumentOrder { get; set; } = false;
     /// <inheritdoc/>
+    public bool UsingTemplateStrings { get; set; } = true;
+    /// <inheritdoc/>
     public IGlobalFunctions GlobalFunctions { get; } = new GlobalFunctions();
     /// <inheritdoc/>
     public GameSpecificRegistry GameSpecificRegistry { get; set; } = new();

--- a/Underanalyzer/Mock/GameContextMock.cs
+++ b/Underanalyzer/Mock/GameContextMock.cs
@@ -72,6 +72,8 @@ public class GameContextMock : IGameContext
     /// <inheritdoc/>
     public bool UsingTemplateStrings { get; set; } = true;
     /// <inheritdoc/>
+    public bool UsingModernTemplateStrings { get; set; } = true;
+    /// <inheritdoc/>
     public IGlobalFunctions GlobalFunctions { get; } = new GlobalFunctions();
     /// <inheritdoc/>
     public GameSpecificRegistry GameSpecificRegistry { get; set; } = new();

--- a/Underanalyzer/VMConstants.cs
+++ b/Underanalyzer/VMConstants.cs
@@ -48,6 +48,9 @@ internal static class VMConstants
     // Function name used to throw an object/exception
     public const string ThrowFunction = "@@throw@@";
 
+    // Function name for template strings
+    public const string TemplateStringFunction = "@@string@@";
+
     // Variable names used by compiler to rewrite try/catch/finally
     public const string TryBreakVariable = "__yy_breakEx";
     public const string TryContinueVariable = "__yy_continueEx";

--- a/Underanalyzer/VMConstants.cs
+++ b/Underanalyzer/VMConstants.cs
@@ -48,8 +48,9 @@ internal static class VMConstants
     // Function name used to throw an object/exception
     public const string ThrowFunction = "@@throw@@";
 
-    // Function name for template strings
-    public const string TemplateStringFunction = "@@string@@";
+    // Function names for template strings
+    public const string TemplateStringFunction = "string";
+    public const string ModernTemplateStringFunction = "@@string@@";
 
     // Variable names used by compiler to rewrite try/catch/finally
     public const string TryBreakVariable = "__yy_breakEx";

--- a/UnderanalyzerTest/LexContext.Tokenize.cs
+++ b/UnderanalyzerTest/LexContext.Tokenize.cs
@@ -316,10 +316,6 @@ public class LexContext_Tokenize
         );
         Assert.Empty(context.CompileContext.Errors);
         Assert.False(context.CompileContext.HasErrors);
-        foreach (var token in context.Tokens)
-        {
-            Console.WriteLine($"{token.GetType().Name}\t{token.ToString()}");
-        }
         TestUtil.AssertTokens([
             ("$\"", typeof(TokenTemplateStringStart)),
             ("meow", typeof(TokenTemplateStringMiddle)),
@@ -380,10 +376,10 @@ public class LexContext_Tokenize
         Assert.False(context.CompileContext.HasErrors);
         TestUtil.AssertTokens([
             ("$\"", typeof(TokenTemplateStringStart)),
-            ("\\\\{\\\\}\\\\\\a\\b\\f\\n\\r\\t\\v\\u00e2\\u61\\x41\\101", typeof(TokenTemplateStringMiddle)),
+            ("\\{\\}\\\\\\a\\b\\f\\n\\r\\t\\v\\u00e2\\u61\\x41\\101", typeof(TokenTemplateStringMiddle)),
             ("\"", typeof(TokenTemplateStringEnd)),
         ], context.Tokens);
-        Assert.Equal("\\\a\b\f\n\r\t\v\u00e2\u0061AA", ((TokenTemplateStringMiddle)context.Tokens[1]).Value);
+        Assert.Equal("{}\\\a\b\f\n\r\t\v\u00e2\u0061AA", ((TokenTemplateStringMiddle)context.Tokens[1]).Value);
     }
 
     [Fact]

--- a/UnderanalyzerTest/LexContext.Tokenize.cs
+++ b/UnderanalyzerTest/LexContext.Tokenize.cs
@@ -438,6 +438,58 @@ public class LexContext_Tokenize
     }
 
     [Fact]
+    public void TestStringTemplateValidNewlines()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            $"\n{
+            a
+            }\nb"
+            """
+        );
+
+        Assert.Empty(context.CompileContext.Errors);
+        Assert.False(context.CompileContext.HasErrors);
+        TestUtil.AssertTokens([
+            ("$\"", typeof(TokenTemplateStringStart)),
+            ("\\n", typeof(TokenTemplateStringMiddle)),
+            ("{", typeof(TokenSeparator)),
+            ("a", typeof(TokenVariable)),
+            ("}", typeof(TokenSeparator)),
+            ("\\nb", typeof(TokenTemplateStringMiddle)),
+            ("\"", typeof(TokenTemplateStringEnd)),
+        ], context.Tokens);
+        Assert.Equal("\n", ((TokenTemplateStringMiddle)context.Tokens[1]).Value);
+        Assert.Equal("\nb", ((TokenTemplateStringMiddle)context.Tokens[5]).Value);
+    }
+
+    [Fact]
+    public void TestBadStringBackslash()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            "hello \
+            """
+        );
+
+        Assert.Single(context.CompileContext.Errors);
+        Assert.True(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
+    public void TestBadStringBackslashTemplate()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            $"hello \
+            """
+        );
+
+        Assert.Single(context.CompileContext.Errors);
+        Assert.True(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
     public void TestHex()
     {
         LexContext context = TestUtil.Lex(

--- a/UnderanalyzerTest/LexContext.Tokenize.cs
+++ b/UnderanalyzerTest/LexContext.Tokenize.cs
@@ -307,6 +307,141 @@ public class LexContext_Tokenize
     }
 
     [Fact]
+    public void TestStringTemplateBasic()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            $"meow{123}{{}}:3"
+            """
+        );
+        Assert.Empty(context.CompileContext.Errors);
+        Assert.False(context.CompileContext.HasErrors);
+        foreach (var token in context.Tokens)
+        {
+            Console.WriteLine($"{token.GetType().Name}\t{token.ToString()}");
+        }
+        TestUtil.AssertTokens([
+            ("$\"", typeof(TokenTemplateStringStart)),
+            ("meow", typeof(TokenTemplateStringMiddle)),
+            ("{", typeof(TokenSeparator)),
+            ("123", typeof(TokenNumber)),
+            ("}", typeof(TokenSeparator)),
+            ("{", typeof(TokenSeparator)),
+            ("{", typeof(TokenSeparator)),
+            ("}", typeof(TokenSeparator)),
+            ("}", typeof(TokenSeparator)),
+            (":3", typeof(TokenTemplateStringMiddle)),
+            ("\"", typeof(TokenTemplateStringEnd)),
+        ], context.Tokens);
+    }
+
+    [Fact]
+    public void TestStringTemplateNested()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            $"m{$"e{$"o"}"}{$"w"}"
+            """
+        );
+        Assert.Empty(context.CompileContext.Errors);
+        Assert.False(context.CompileContext.HasErrors);
+        TestUtil.AssertTokens([
+            ("$\"", typeof(TokenTemplateStringStart)),
+            ("m", typeof(TokenTemplateStringMiddle)),
+            ("{", typeof(TokenSeparator)),
+            ("$\"", typeof(TokenTemplateStringStart)),
+            ("e", typeof(TokenTemplateStringMiddle)),
+            ("{", typeof(TokenSeparator)),
+            ("$\"", typeof(TokenTemplateStringStart)),
+            ("o", typeof(TokenTemplateStringMiddle)),
+            ("\"", typeof(TokenTemplateStringEnd)),
+            ("}", typeof(TokenSeparator)),
+            ("\"", typeof(TokenTemplateStringEnd)),
+            ("}", typeof(TokenSeparator)),
+            ("{", typeof(TokenSeparator)),
+            ("$\"", typeof(TokenTemplateStringStart)),
+            ("w", typeof(TokenTemplateStringMiddle)),
+            ("\"", typeof(TokenTemplateStringEnd)),
+            ("}", typeof(TokenSeparator)),
+            ("\"", typeof(TokenTemplateStringEnd)),
+        ], context.Tokens);
+    }
+
+    [Fact]
+    public void TestStringTemplateEscapes()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            $"\{\}\\\a\b\f\n\r\t\v\u00e2\u61\x41\101"
+            """
+        );
+
+        Assert.Empty(context.CompileContext.Errors);
+        Assert.False(context.CompileContext.HasErrors);
+        TestUtil.AssertTokens([
+            ("$\"", typeof(TokenTemplateStringStart)),
+            ("\\\\{\\\\}\\\\\\a\\b\\f\\n\\r\\t\\v\\u00e2\\u61\\x41\\101", typeof(TokenTemplateStringMiddle)),
+            ("\"", typeof(TokenTemplateStringEnd)),
+        ], context.Tokens);
+        Assert.Equal("\\\a\b\f\n\r\t\v\u00e2\u0061AA", ((TokenTemplateStringMiddle)context.Tokens[1]).Value);
+    }
+
+    [Fact]
+    public void TestStringTemplateUnclosed()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            $"
+            """
+        );
+
+        Assert.Single(context.CompileContext.Errors);
+        Assert.True(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
+    public void TestStringTemplateUnclosed2()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            $"{
+            """
+        );
+
+        Assert.Equal(2, context.CompileContext.Errors.Count);
+        Assert.True(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
+    public void TestStringTemplateUnclosed3()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            $"a
+            """
+        );
+
+        Assert.Single(context.CompileContext.Errors);
+        Assert.True(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
+    public void TestStringTemplateNewlines()
+    {
+        LexContext context = TestUtil.Lex(
+            """
+            $"
+            a
+            b
+            "
+            """
+        );
+
+        Assert.Single(context.CompileContext.Errors);
+        Assert.True(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
     public void TestHex()
     {
         LexContext context = TestUtil.Lex(

--- a/UnderanalyzerTest/ParseContext.Parse.cs
+++ b/UnderanalyzerTest/ParseContext.Parse.cs
@@ -1124,7 +1124,11 @@ public class ParseContext_Parse
         ParseContext context = TestUtil.Parse(
             """
             a = $"{""} {{}}";
-            """
+            """,
+            new Underanalyzer.Mock.GameContextMock()
+            {
+                UsingModernTemplateStrings = false
+            }
         );
 
         Assert.Empty(context.CompileContext.Errors);
@@ -1136,6 +1140,31 @@ public class ParseContext_Parse
 
         var call = (SimpleFunctionCallNode)assign.Expression;
         Assert.Equal(VMConstants.TemplateStringFunction, call.FunctionName);
+        Assert.Equal("{0} {1}", ((StringNode)call.Arguments[0]).Value);
+
+        Assert.Equal("", ((StringNode)call.Arguments[1]).Value);
+
+        Assert.Equal(VMConstants.NewObjectFunction, ((SimpleFunctionCallNode)call.Arguments[2]).FunctionName);
+    }
+
+    [Fact]
+    public void TestModernTemplateStrings()
+    {
+        ParseContext context = TestUtil.Parse(
+            """
+            a = $"{""} {{}}";
+            """
+        );
+
+        Assert.Empty(context.CompileContext.Errors);
+        Assert.False(context.CompileContext.HasErrors);
+
+        var node = Assert.Single(((BlockNode)context.Root!).Children);
+        AssignNode assign = (AssignNode)node;
+        Assert.Equal("a", ((SimpleVariableNode)assign.Destination).VariableName);
+
+        var call = (SimpleFunctionCallNode)assign.Expression;
+        Assert.Equal(VMConstants.ModernTemplateStringFunction, call.FunctionName);
         Assert.Equal("{0} {1}", ((StringNode)call.Arguments[0]).Value);
 
         Assert.Equal("", ((StringNode)call.Arguments[1]).Value);

--- a/UnderanalyzerTest/ParseContext.Parse.cs
+++ b/UnderanalyzerTest/ParseContext.Parse.cs
@@ -1117,4 +1117,32 @@ public class ParseContext_Parse
             }
         );
     }
+
+    [Fact]
+    public void TestTemplateStrings()
+    {
+        ParseContext context = TestUtil.Parse(
+            """
+            a = $"{""} {{}}";
+            """
+        );
+
+        Assert.Empty(context.CompileContext.Errors);
+        Assert.False(context.CompileContext.HasErrors);
+
+        var node = Assert.Single(((BlockNode)context.Root!).Children);
+        AssignNode assign = (AssignNode)node;
+        Assert.Equal("a", ((SimpleVariableNode)assign.Destination).VariableName);
+
+        var call = (SimpleFunctionCallNode)assign.Expression;
+        Assert.Equal(VMConstants.TemplateStringFunction, call.FunctionName);
+        Assert.Equal("{0} {1}", ((StringNode)call.Arguments[0]).Value);
+
+        Assert.Equal("", ((StringNode)call.Arguments[1]).Value);
+
+        var structDecl = (FunctionDeclNode)call.Arguments[2];
+        Assert.True(structDecl.IsStruct);
+        Assert.False(structDecl.IsStatement);
+        Assert.True(structDecl.IsConstructor);
+    }
 }

--- a/UnderanalyzerTest/ParseContext.Parse.cs
+++ b/UnderanalyzerTest/ParseContext.Parse.cs
@@ -1140,9 +1140,6 @@ public class ParseContext_Parse
 
         Assert.Equal("", ((StringNode)call.Arguments[1]).Value);
 
-        var structDecl = (FunctionDeclNode)call.Arguments[2];
-        Assert.True(structDecl.IsStruct);
-        Assert.False(structDecl.IsStatement);
-        Assert.True(structDecl.IsConstructor);
+        Assert.Equal(VMConstants.NewObjectFunction, ((SimpleFunctionCallNode)call.Arguments[2]).FunctionName);
     }
 }

--- a/UnderanalyzerTest/RoundTrip.cs
+++ b/UnderanalyzerTest/RoundTrip.cs
@@ -1885,6 +1885,8 @@ public class RoundTrip
             unresolved = string(some_variable);
             old_bug = $"\{{123}}";
             old_bug_equivalent = string("{{0}}", 123);
+            spaces_test = string("{ 0}", 123);
+            spaces_test_2 = string("{0 }", 123);
             """,
             """
             a = $"meow {x} lalala {""}";
@@ -1899,6 +1901,8 @@ public class RoundTrip
             unresolved = string(some_variable);
             old_bug = string("{{0}}", 123);
             old_bug_equivalent = string("{{0}}", 123);
+            spaces_test = string("{ 0}", 123);
+            spaces_test_2 = string("{0 }", 123);
             """,
             false,
             new GameContextMock()
@@ -1927,6 +1931,8 @@ public class RoundTrip
             unresolved_1 = string(some_variable);
             unresolved_2 = @@string@@(some_variable);
             old_bug_now_fixed = $"\{{123}}";
+            spaces_test = @@string@@("{ 0}", 123);
+            spaces_test_2 = @@string@@("{0 }", 123);
             """,
             """
             a = $"meow {x} lalala {""}";
@@ -1941,6 +1947,8 @@ public class RoundTrip
             unresolved_1 = string(some_variable);
             unresolved_2 = @@string@@(some_variable);
             old_bug_now_fixed = $"\{{123}}";
+            spaces_test = @@string@@("{ 0}", 123);
+            spaces_test_2 = @@string@@("{0 }", 123);
             """
         );
     }

--- a/UnderanalyzerTest/RoundTrip.cs
+++ b/UnderanalyzerTest/RoundTrip.cs
@@ -1867,7 +1867,49 @@ public class RoundTrip
     }
 
     [Fact]
-    public void TestTemplateString()
+    public void TestTemplateStrings()
+    {
+        TestUtil.VerifyRoundTrip(
+            """
+            a = $"meow {x} lalala {$""}";
+            b = string("{0} now there are two of them. there are two {0}", x);
+            c = string("{0} {1}", x);
+            d = $"\{";
+            e = $"\{x\} \{ 3\} \{\}";
+            f = $"{5}";
+            g = $"Split\n{
+            across
+            }\nmultiple lines";
+            h = $"\{x\} { 3} \{\}";
+            ambiguous_example = string("{0} {1} {2}", 1, 2, 3);
+            unresolved = string(some_variable);
+            old_bug = $"\{{123}}";
+            old_bug_equivalent = string("{{0}}", 123);
+            """,
+            """
+            a = $"meow {x} lalala {""}";
+            b = string("{0} now there are two of them. there are two {0}", x);
+            c = string("{0} {1}", x);
+            d = "{";
+            e = "{x} { 3} {}";
+            f = $"{5}";
+            g = $"Split\n{across}\nmultiple lines";
+            h = $"\{x} {3} \{}";
+            ambiguous_example = $"{1} {2} {3}";
+            unresolved = string(some_variable);
+            old_bug = string("{{0}}", 123);
+            old_bug_equivalent = string("{{0}}", 123);
+            """,
+            false,
+            new GameContextMock()
+            {
+                UsingModernTemplateStrings = false
+            }
+        );
+    }
+
+    [Fact]
+    public void TestModernTemplateStrings()
     {
         TestUtil.VerifyRoundTrip(
             """
@@ -1876,6 +1918,29 @@ public class RoundTrip
             c = @@string@@("{0} {1}", x);
             d = $"\{";
             e = $"\{x\} \{ 3\} \{\}";
+            f = $"{5}";
+            g = $"Split\n{
+            across
+            }\nmultiple lines";
+            h = $"\{x\} { 3} \{\}";
+            no_longer_ambiguous_example = string("{0} {1} {2}", 1, 2, 3);
+            unresolved_1 = string(some_variable);
+            unresolved_2 = @@string@@(some_variable);
+            old_bug_now_fixed = $"\{{123}}";
+            """,
+            """
+            a = $"meow {x} lalala {""}";
+            b = @@string@@("{0} now there are two of them. there are two {0}", x);
+            c = @@string@@("{0} {1}", x);
+            d = "{";
+            e = "{x} { 3} {}";
+            f = $"{5}";
+            g = $"Split\n{across}\nmultiple lines";
+            h = $"\{x} {3} \{}";
+            no_longer_ambiguous_example = string("{0} {1} {2}", 1, 2, 3);
+            unresolved_1 = string(some_variable);
+            unresolved_2 = @@string@@(some_variable);
+            old_bug_now_fixed = $"\{{123}}";
             """
         );
     }

--- a/UnderanalyzerTest/RoundTrip.cs
+++ b/UnderanalyzerTest/RoundTrip.cs
@@ -1865,4 +1865,18 @@ public class RoundTrip
             }
         );
     }
+
+    [Fact]
+    public void TestTemplateString()
+    {
+        TestUtil.VerifyRoundTrip(
+            """
+            a = $"meow {x} lalala {$""}";
+            b = @@string@@("{0} now there are two of them. there are two {0}", x);
+            c = @@string@@("{0} {1}", x);
+            d = $"\{";
+            e = $"\{x\} \{ 3\} \{\}";
+            """
+        );
+    }
 }


### PR DESCRIPTION
This adds support for template string syntax to the compiler and decompiler.

Specifically, `FunctionCallNode`s with `@@string@@` are rewritten as `TemplateStringNode`s in the cleanup step if applicable. For any cases that seem problematic (e.g. malformed calls with extra arguments, not enough arguments), it falls back to generating a regular function call.

Since this might break any projects that rely on the old behavior, a feature flag has been added to `IDecompileOptions` (on by default). This also changes the public API.

There are also some new tests.