### PR TITLE
Handle impossible fields in struct literals

### DIFF
--- a/Underanalyzer/Compiler/Lexer/Token.cs
+++ b/Underanalyzer/Compiler/Lexer/Token.cs
@@ -462,6 +462,14 @@ internal sealed record TokenVariable : IToken
         BuiltinVariable = Context.CompileContext.GameContext.Builtins.LookupBuiltinVariable(Text);
     }
 
+    public TokenVariable(TokenBoolean boolean)
+    {
+        Context = boolean.Context;
+        TextPosition = boolean.TextPosition;
+        Text = boolean.ToString();
+        BuiltinVariable = null;
+    }
+
     public override string ToString()
     {
         return Text;

--- a/Underanalyzer/Compiler/Nodes/FunctionDeclNode.cs
+++ b/Underanalyzer/Compiler/Nodes/FunctionDeclNode.cs
@@ -287,6 +287,7 @@ internal sealed class FunctionDeclNode : IMaybeStatementASTNode
         // Read assignments from struct literal
         while (!context.EndOfCode && !context.IsCurrentToken(SeparatorKind.BlockClose, KeywordKind.End))
         {
+            bool parsedStringName = false;
             if (context.Tokens[context.Position] is not TokenVariable variable)
             {
                 // Failed to find a variable here... check if a constant/asset reference, string, or keyword
@@ -301,10 +302,15 @@ internal sealed class FunctionDeclNode : IMaybeStatementASTNode
                 else if (context.Tokens[context.Position] is TokenString str)
                 {
                     variable = new TokenVariable(str);
+                    parsedStringName = true;
                 }
                 else if (context.Tokens[context.Position] is TokenKeyword keyword)
                 {
                     variable = new TokenVariable(keyword);
+                }
+                else if (context.Tokens[context.Position] is TokenBoolean boolean)
+                {
+                    variable = new TokenVariable(boolean);
                 }
                 else
                 {
@@ -357,20 +363,50 @@ internal sealed class FunctionDeclNode : IMaybeStatementASTNode
                 }
             }
 
-            // Create assignment statement, or a function call to 'variable_struct_set' if the name is not a valid identifier.
-            if (!IsValidIdentifier(variable.Text))
+            // Create assignment statement (or a function call to "variable_struct_set" in some cases)
+            string variableName = variable.Text;
+            bool modernSpecialCaseNames = context.CompileContext.GameContext.UsingStructSpecialCaseNames;
+            if (string.IsNullOrEmpty(variableName))
             {
-                List<IASTNode> callArgs =
-                [
-                    new SimpleFunctionCallNode(VMConstants.SelfFunction, null, []),
-                    new StringNode(variable.Text, variable),
-                    value
-                ];
-                SimpleFunctionCallNode callNode = new("variable_struct_set", null, callArgs)
+                context.CompileContext.PushError("Struct field name cannot be empty", variable);
+            }
+            else if (variableName[0] is not ((>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '_'))
+            {
+                if (context.CompileContext.GameContext.UsingStructAnyNonemptyString)
                 {
-                    IsStatement = true
-                };
-                block.Children.Add(callNode);
+                    List<IASTNode> callArgs =
+                    [
+                        new SimpleFunctionCallNode(VMConstants.SelfFunction, null, []),
+                        new StringNode(variable.Text, variable),
+                        value
+                    ];
+                    SimpleFunctionCallNode callNode = new(VMConstants.StructSetFunction, null, callArgs)
+                    {
+                        IsStatement = true
+                    };
+                    block.Children.Add(callNode);
+                }
+                else
+                {
+                    context.CompileContext.PushError("Struct field name must start with a-z, A-Z, or _ in this GameMaker version", variable);
+                }
+            }
+            else if (modernSpecialCaseNames && !parsedStringName && VMConstants.ModernDisallowedStructKeywords.Contains(variableName))
+            {
+                context.CompileContext.PushError("Invalid keyword used for struct field name, must surround with quotes", variable);
+            }
+            else if (modernSpecialCaseNames && (variableName == "self" || variableName == "other"))
+            {
+                DotVariableNode destination = new(
+                    new SimpleFunctionCallNode(VMConstants.SelfFunction, 
+                                               context.CompileContext.GameContext.Builtins.LookupBuiltinFunction(VMConstants.SelfFunction), 
+                                               []),
+                    variable);
+                block.Children.Add(new AssignNode(AssignNode.AssignKind.Normal, destination, value));
+            }
+            else if (!modernSpecialCaseNames && !parsedStringName && VMConstants.OldDisallowedStructKeywords.Contains(variableName))
+            {
+                context.CompileContext.PushError("Invalid keyword used for struct field name in this GameMaker version, must surround with quotes", variable);
             }
             else
             {
@@ -650,30 +686,5 @@ internal sealed class FunctionDeclNode : IMaybeStatementASTNode
         {
             yield return InheritanceCall;
         }
-    }
-
-    private static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrEmpty(name) || VMConstants.LanguageKeywords.Contains(name))
-        {
-            return false;
-        }
-
-        // Check first character
-        if (name[0] is not (>= 'a' and <= 'z' or >= 'A' and <= 'Z' or '_'))
-        {
-            return false;
-        }
-
-        // Check remaining characters
-        for (int i = 1; i < name.Length; i++)
-        {
-            if (name[i] is not (>= 'a' and <= 'z' or >= 'A' and <= 'Z' or >= '0' and <= '9' or '_'))
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/Underanalyzer/Compiler/Nodes/FunctionDeclNode.cs
+++ b/Underanalyzer/Compiler/Nodes/FunctionDeclNode.cs
@@ -357,12 +357,29 @@ internal sealed class FunctionDeclNode : IMaybeStatementASTNode
                 }
             }
 
-            // Create assignment statement
-            SimpleVariableNode destination = new(variable)
+            // Create assignment statement, or a function call to 'variable_struct_set' if the name is not a valid identifier.
+            if (!IsValidIdentifier(variable.Text))
             {
-                StructVariable = true
-            };
-            block.Children.Add(new AssignNode(AssignNode.AssignKind.Normal, destination, value));
+                List<IASTNode> callArgs = new(3)
+                {
+                    new SimpleFunctionCallNode(VMConstants.SelfFunction, null, []),
+                    new StringNode(variable.Text, variable),
+                    value
+                };
+                SimpleFunctionCallNode callNode = new("variable_struct_set", null, callArgs)
+                {
+                    IsStatement = true
+                };
+                block.Children.Add(callNode);
+            }
+            else
+            {
+                SimpleVariableNode destination = new(variable)
+                {
+                    StructVariable = true
+                };
+                block.Children.Add(new AssignNode(AssignNode.AssignKind.Normal, destination, value));
+            }
 
             // Expect "," or "}"
             if (context.IsCurrentToken(SeparatorKind.Comma))
@@ -633,5 +650,35 @@ internal sealed class FunctionDeclNode : IMaybeStatementASTNode
         {
             yield return InheritanceCall;
         }
+    }
+
+    private static bool IsValidIdentifier(string name)
+    {
+        if (string.IsNullOrEmpty(name) || VMConstants.LanguageKeywords.Contains(name))
+        {
+            return false;
+        }
+
+        char firstChar = name[0];
+        if ((firstChar < 'a' || firstChar > 'z') && 
+            (firstChar < 'A' || firstChar > 'Z') && 
+            firstChar != '_')
+        {
+            return false;
+        }
+
+        for (int i = 1; i < name.Length; i++)
+        {
+            char c = name[i];
+            if ((c < 'a' || c > 'z') &&
+                (c < 'A' || c > 'Z') &&
+                (c < '0' || c > '9') &&
+                c != '_')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/Underanalyzer/Compiler/Nodes/FunctionDeclNode.cs
+++ b/Underanalyzer/Compiler/Nodes/FunctionDeclNode.cs
@@ -360,12 +360,12 @@ internal sealed class FunctionDeclNode : IMaybeStatementASTNode
             // Create assignment statement, or a function call to 'variable_struct_set' if the name is not a valid identifier.
             if (!IsValidIdentifier(variable.Text))
             {
-                List<IASTNode> callArgs = new(3)
-                {
+                List<IASTNode> callArgs =
+                [
                     new SimpleFunctionCallNode(VMConstants.SelfFunction, null, []),
                     new StringNode(variable.Text, variable),
                     value
-                };
+                ];
                 SimpleFunctionCallNode callNode = new("variable_struct_set", null, callArgs)
                 {
                     IsStatement = true
@@ -659,21 +659,16 @@ internal sealed class FunctionDeclNode : IMaybeStatementASTNode
             return false;
         }
 
-        char firstChar = name[0];
-        if ((firstChar < 'a' || firstChar > 'z') && 
-            (firstChar < 'A' || firstChar > 'Z') && 
-            firstChar != '_')
+        // Check first character
+        if (name[0] is not (>= 'a' and <= 'z' or >= 'A' and <= 'Z' or '_'))
         {
             return false;
         }
 
+        // Check remaining characters
         for (int i = 1; i < name.Length; i++)
         {
-            char c = name[i];
-            if ((c < 'a' || c > 'z') &&
-                (c < 'A' || c > 'Z') &&
-                (c < '0' || c > '9') &&
-                c != '_')
+            if (name[i] is not (>= 'a' and <= 'z' or >= 'A' and <= 'Z' or >= '0' and <= '9' or '_'))
             {
                 return false;
             }

--- a/Underanalyzer/Decompiler/AST/Nodes/AssignNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/AssignNode.cs
@@ -296,10 +296,21 @@ public class AssignNode : IStatementNode, IExpressionNode, IBlockCleanupNode
     /// <summary>
     /// Returns whether a variable name is a valid GML identifier or not.
     /// </summary>
-    private static bool VariableNameIsValidIdentifier(string name)
+    private static bool VariableNameIsValidIdentifier(IGameContext context, string name)
     {
         // If name is empty, it's clearly not valid
         if (name.Length == 0)
+        {
+            return false;
+        }
+
+        // If using a disallowed keyword, that's also not valid
+        bool modernSpecialCaseNames = context.UsingStructSpecialCaseNames;
+        if (modernSpecialCaseNames && VMConstants.ModernDisallowedStructKeywords.Contains(name))
+        {
+            return false;
+        }
+        if (!modernSpecialCaseNames && VMConstants.OldDisallowedStructKeywords.Contains(name))
         {
             return false;
         }
@@ -339,14 +350,10 @@ public class AssignNode : IStatementNode, IExpressionNode, IBlockCleanupNode
                 if (printer.StructArguments is not null)
                 {
                     // We're inside a struct initialization block
-                    if (Variable is VariableNode { Variable.Name.Content: string variableName } varNode)
+                    if (Variable is VariableNode { Variable.Name.Content: string variableName })
                     {
                         // Write just the variable name if possible
-                        if (varNode.WriteInQuotes)
-                        {
-                            StringNode.PrintGMS2String(printer, variableName);
-                        }
-                        else if (VariableNameIsValidIdentifier(variableName))
+                        if (VariableNameIsValidIdentifier(printer.Context.GameContext, variableName))
                         {
                             printer.Write(variableName);
                         }

--- a/Underanalyzer/Decompiler/AST/Nodes/AssignNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/AssignNode.cs
@@ -339,10 +339,14 @@ public class AssignNode : IStatementNode, IExpressionNode, IBlockCleanupNode
                 if (printer.StructArguments is not null)
                 {
                     // We're inside a struct initialization block
-                    if (Variable is VariableNode { Variable.Name.Content: string variableName })
+                    if (Variable is VariableNode { Variable.Name.Content: string variableName } varNode)
                     {
                         // Write just the variable name if possible
-                        if (VariableNameIsValidIdentifier(variableName))
+                        if (varNode.WriteInQuotes)
+                        {
+                            StringNode.PrintGMS2String(printer, variableName);
+                        }
+                        else if (VariableNameIsValidIdentifier(variableName))
                         {
                             printer.Write(variableName);
                         }

--- a/Underanalyzer/Decompiler/AST/Nodes/StructNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/StructNode.cs
@@ -58,6 +58,19 @@ public class StructNode(BlockNode body, ASTFragmentContext fragmentContext) : IF
     public IExpressionNode PostClean(ASTCleaner cleaner)
     {
         Body.PostCleanStruct(cleaner);
+
+        // Replace impossible fields that use 'variable_struct_set' and make them use quoted fields instead.
+        for (int i = 0; i < Body.Children.Count; i++)
+        {
+            IStatementNode child = Body.Children[i];
+            if (child is FunctionCallNode callNode && 
+                callNode.Function.Name.Content == "variable_struct_set" && 
+                callNode.Arguments.Count == 3)
+            {
+                Body.Children[i] = new AssignNode(callNode.Arguments[1], callNode.Arguments[2]);
+            }
+        }
+
         return this;
     }
 

--- a/Underanalyzer/Decompiler/AST/Nodes/StructNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/StructNode.cs
@@ -59,13 +59,15 @@ public class StructNode(BlockNode body, ASTFragmentContext fragmentContext) : IF
     {
         Body.PostCleanStruct(cleaner);
 
-        // Replace impossible fields that use 'variable_struct_set' and make them use quoted fields instead.
+        // Replace impossible fields that use "variable_struct_set" and make them use quoted fields instead.
         for (int i = 0; i < Body.Children.Count; i++)
         {
-            IStatementNode child = Body.Children[i];
-            if (child is FunctionCallNode callNode && 
-                callNode.Function.Name.Content == "variable_struct_set" && 
-                callNode.Arguments.Count == 3)
+            if (Body.Children[i] is FunctionCallNode 
+                { 
+                    Function.Name.Content: VMConstants.StructSetFunction, 
+                    Arguments.Count: 3 
+                } 
+                callNode)
             {
                 Body.Children[i] = new AssignNode(callNode.Arguments[1], callNode.Arguments[2]);
             }

--- a/Underanalyzer/Decompiler/AST/Nodes/VariableNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/VariableNode.cs
@@ -48,12 +48,6 @@ public class VariableNode(IGMVariable variable, VariableType referenceType, IExp
     /// Meant for tracking obscure compiler quirks.
     /// </summary>
     public bool ForceSelf { get; set; } = false;
-
-    /// <summary>
-    /// Whether this variable node should be written in quotes.
-    /// Used for impossible fields in struct literals.
-    /// </summary>
-    public bool WriteInQuotes { get; set; } = false;
     
     /// <inheritdoc/>
     public bool Duplicated { get; set; } = false;
@@ -422,15 +416,7 @@ public class VariableNode(IGMVariable variable, VariableType referenceType, IExp
         if (argIndex == -1 || printer.TopFragmentContext.IsRootFragment)
         {
             // Variable name
-            if (WriteInQuotes)
-            {
-                // This is the only case where the variable name needs to be written in quotes.
-                printer.Write($"\"{variable.Name.Content}\"");
-            }
-            else
-            {
-                printer.Write(Variable.Name.Content);
-            }
+            printer.Write(Variable.Name.Content);
         }
         else
         {

--- a/Underanalyzer/Decompiler/AST/Nodes/VariableNode.cs
+++ b/Underanalyzer/Decompiler/AST/Nodes/VariableNode.cs
@@ -49,6 +49,12 @@ public class VariableNode(IGMVariable variable, VariableType referenceType, IExp
     /// </summary>
     public bool ForceSelf { get; set; } = false;
 
+    /// <summary>
+    /// Whether this variable node should be written in quotes.
+    /// Used for impossible fields in struct literals.
+    /// </summary>
+    public bool WriteInQuotes { get; set; } = false;
+    
     /// <inheritdoc/>
     public bool Duplicated { get; set; } = false;
 
@@ -416,7 +422,15 @@ public class VariableNode(IGMVariable variable, VariableType referenceType, IExp
         if (argIndex == -1 || printer.TopFragmentContext.IsRootFragment)
         {
             // Variable name
-            printer.Write(Variable.Name.Content);
+            if (WriteInQuotes)
+            {
+                // This is the only case where the variable name needs to be written in quotes.
+                printer.Write($"\"{variable.Name.Content}\"");
+            }
+            else
+            {
+                printer.Write(Variable.Name.Content);
+            }
         }
         else
         {

--- a/Underanalyzer/IGameContext.cs
+++ b/Underanalyzer/IGameContext.cs
@@ -90,6 +90,11 @@ public interface IGameContext
     public bool UsingNewFunctionResolution { get; }
 
     /// <summary>
+    /// <see langword="true"/> if the game uses special variable name cases for structs introduced in GameMaker 2024.13; <see langword="false"/> otherwise.
+    /// </summary>
+    public bool UsingStructSpecialCaseNames { get; }
+
+    /// <summary>
     /// <see langword="true"/> if the game uses bytecode 14 or lower; <see langword="true"/> otherwise.
     /// </summary>
     public bool Bytecode14OrLower { get; }
@@ -219,6 +224,11 @@ public interface IGameContext
     /// This changes the code generation for template strings to match what is observed in GameMaker 2024.14 and above.
     /// </remarks>
     public bool UsingModernTemplateStrings { get; }
+
+    /// <summary>
+    /// <see langword="true"/> if the game supports any non-empty string as a struct variable, introduced in GameMaker 2024.14; <see langword="false"/> otherwise.
+    /// </summary>
+    public bool UsingStructAnyNonemptyString { get; }
 
     /// <summary>
     /// Interface for getting global functions.

--- a/Underanalyzer/Mock/BuiltinsMock.cs
+++ b/Underanalyzer/Mock/BuiltinsMock.cs
@@ -38,7 +38,7 @@ public class BuiltinsMock : IBuiltins
         { "script_execute", new("script_execute", 1, int.MaxValue) },
         { "array_set", new("array_set", 3, 3) },
         { "array_create", new("array_create", 1, 2) },
-        { "variable_struct_set", new("variable_struct_set", 3, 3) },
+        { VMConstants.StructSetFunction, new(VMConstants.StructSetFunction, 3, 3) },
         { VMConstants.SelfFunction, new(VMConstants.SelfFunction, 0, 0) },
         { VMConstants.OtherFunction, new(VMConstants.OtherFunction, 0, 0) },
         { VMConstants.GlobalFunction, new(VMConstants.GlobalFunction, 0, 0) },

--- a/Underanalyzer/Mock/BuiltinsMock.cs
+++ b/Underanalyzer/Mock/BuiltinsMock.cs
@@ -38,6 +38,7 @@ public class BuiltinsMock : IBuiltins
         { "script_execute", new("script_execute", 1, int.MaxValue) },
         { "array_set", new("array_set", 3, 3) },
         { "array_create", new("array_create", 1, 2) },
+        { "variable_struct_set", new("variable_struct_set", 3, 3) },
         { VMConstants.SelfFunction, new(VMConstants.SelfFunction, 0, 0) },
         { VMConstants.OtherFunction, new(VMConstants.OtherFunction, 0, 0) },
         { VMConstants.GlobalFunction, new(VMConstants.GlobalFunction, 0, 0) },

--- a/Underanalyzer/Mock/GameContextMock.cs
+++ b/Underanalyzer/Mock/GameContextMock.cs
@@ -44,6 +44,8 @@ public class GameContextMock : IGameContext
     /// <inheritdoc/>
     public bool UsingNewFunctionVariables { get; set; } = false;
     /// <inheritdoc/>
+    public bool UsingStructSpecialCaseNames { get; set; } = false;
+    /// <inheritdoc/>
     public bool UsingSelfToBuiltin { get; set; } = false;
     /// <inheritdoc/>
     public bool UsingGlobalConstantFunction { get; set; } = false;
@@ -73,6 +75,8 @@ public class GameContextMock : IGameContext
     public bool UsingTemplateStrings { get; set; } = true;
     /// <inheritdoc/>
     public bool UsingModernTemplateStrings { get; set; } = true;
+    /// <inheritdoc/>
+    public bool UsingStructAnyNonemptyString { get; set; } = false;
     /// <inheritdoc/>
     public IGlobalFunctions GlobalFunctions { get; } = new GlobalFunctions();
     /// <inheritdoc/>

--- a/Underanalyzer/Mock/VMAssemblyMock.cs
+++ b/Underanalyzer/Mock/VMAssemblyMock.cs
@@ -247,11 +247,12 @@ public static class VMAssembly
                         {
                             throw new Exception("Pop needs parameter");
                         }
+                        string data = string.Join(' ', parts[1..]).Trim();
 
                         // Parse swap variant
                         if (instr.Type1 == IGMInstruction.DataType.Int16)
                         {
-                            if (!byte.TryParse(parts[1], out byte popSwapSize) || popSwapSize < 5 || popSwapSize > 6)
+                            if (!byte.TryParse(data, out byte popSwapSize) || popSwapSize < 5 || popSwapSize > 6)
                             {
                                 throw new Exception("Unexpected pop swap size");
                             }
@@ -260,9 +261,9 @@ public static class VMAssembly
                         }
 
                         // Parse variable destination
-                        if (!ParseVariableFromString(parts[1], variables, out var variable, out var varType, out var instType))
+                        if (!ParseVariableFromString(data, variables, out var variable, out var varType, out var instType))
                         {
-                            throw new Exception($"Failed to parse variable {parts[1]}");
+                            throw new Exception($"Failed to parse variable {data}");
                         }
                         instr.ResolvedVariable = variable;
                         instr.ReferenceVarType = varType;
@@ -346,7 +347,7 @@ public static class VMAssembly
                         {
                             throw new Exception("Push instruction needs data");
                         }
-                        string data = parts[1];
+                        string data = string.Join(' ', parts[1..]).Trim();
 
                         switch (type1)
                         {
@@ -402,7 +403,7 @@ public static class VMAssembly
                             case IGMInstruction.DataType.Variable:
                                 if (!ParseVariableFromString(data, variables, out var variable, out var varType, out var instType))
                                 {
-                                    throw new Exception($"Failed to parse variable {parts[1]}");
+                                    throw new Exception($"Failed to parse variable {data}");
                                 }
                                 instr.ResolvedVariable = variable;
                                 instr.ReferenceVarType = varType;
@@ -579,6 +580,16 @@ public static class VMAssembly
 
         // Get actual variable name
         str = str[(dot + 1)..];
+
+        // If the variable name starts with ", treat it as a string we need to deal with escapes in
+        if (str.StartsWith('"'))
+        {
+            if (!str.EndsWith('"'))
+            {
+                throw new Exception("Expected end quote at end of variable name");
+            }
+            str = UnescapeStringContents(str[1..^1]);
+        }
 
         // Update variable
         variable = new GMVariable(new GMString(str))

--- a/Underanalyzer/VMConstants.cs
+++ b/Underanalyzer/VMConstants.cs
@@ -60,6 +60,9 @@ internal static class VMConstants
     // Function name used to set struct variables (used to de-optimize to be closer to source code)
     public const string StructGetFromHashFunction = "struct_get_from_hash";
 
+    // Function name used to set a variable on a struct directly, by string name
+    public const string StructSetFunction = "variable_struct_set";
+
     // Special-case GML functions used during macro resolution
     public const string ChooseFunction = "choose";
     public const string ScriptExecuteFunction = "script_execute";
@@ -91,15 +94,19 @@ internal static class VMConstants
         "phy_col_normal_x",
         "phy_col_normal_y"
     ];
-    
-    // Language keywords
-    public static readonly HashSet<string> LanguageKeywords =
+
+    // Keywords disallowed to be directly used in structs, without quotes (in older versions)
+    public static readonly HashSet<string> OldDisallowedStructKeywords =
     [
         "if",
+        "then",
         "else",
-        "do",
-        "while",
+        "begin",
+        "end",
         "for",
+        "while",
+        "do",
+        "until",
         "repeat",
         "switch",
         "case",
@@ -108,18 +115,14 @@ internal static class VMConstants
         "continue",
         "with",
         "new",
-        "constructor",
         "function",
         "return",
         "exit",
         "var",
-        "until",
+        "not",
         "and",
         "or",
         "xor",
-        "begin",
-        "end",
-        "then",
         "mod",
         "div",
         "throw",
@@ -127,14 +130,20 @@ internal static class VMConstants
         "try",
         "catch",
         "finally",
+        "enum"
+    ];
+
+    // Keywords disallowed to be directly used in structs, without quotes (in newer versions)
+    public static readonly HashSet<string> ModernDisallowedStructKeywords =
+    [
+        "end",
+        "not",
+        "and",
+        "or",
+        "xor",
+        "mod",
+        "div",
         "enum",
-        "true",
-        "false",
-        "self",
-        "other",
-        "all",
-        "noone",
-        "global",
-        "undefined"
+        "function"
     ];
 }

--- a/Underanalyzer/VMConstants.cs
+++ b/Underanalyzer/VMConstants.cs
@@ -91,4 +91,50 @@ internal static class VMConstants
         "phy_col_normal_x",
         "phy_col_normal_y"
     ];
+    
+    // Language keywords
+    public static readonly HashSet<string> LanguageKeywords =
+    [
+        "if",
+        "else",
+        "do",
+        "while",
+        "for",
+        "repeat",
+        "switch",
+        "case",
+        "default",
+        "break",
+        "continue",
+        "with",
+        "new",
+        "constructor",
+        "function",
+        "return",
+        "exit",
+        "var",
+        "until",
+        "and",
+        "or",
+        "xor",
+        "begin",
+        "end",
+        "then",
+        "mod",
+        "div",
+        "throw",
+        "static",
+        "try",
+        "catch",
+        "finally",
+        "enum",
+        "true",
+        "false",
+        "self",
+        "other",
+        "all",
+        "noone",
+        "global",
+        "undefined"
+    ];
 }

--- a/UnderanalyzerTest/DecompileContext.DecompileToString.Locals.cs
+++ b/UnderanalyzerTest/DecompileContext.DecompileToString.Locals.cs
@@ -1670,54 +1670,6 @@ public class DecompileContext_DecompileToString_Locals
     }
 
     [Fact]
-    public void TestStructWithImpossibleField()
-    {
-        TestUtil.VerifyDecompileResult(
-            """
-            :[0]
-            pushi.e 123
-            pop.v.i local.a
-            pushloc.v local.a
-            b [2]
-            
-            > gml_Script____struct___Test (locals=0, args=0)
-            :[1]
-            pushi.e -15
-            pushi.e 0
-            push.v [array]self.argument
-            pop.v.v self.c
-            pushi.e -15
-            pushi.e 0
-            push.v [array]self.argument
-            push.s "("
-            call.i @@This@@ 0
-            call.i variable_struct_set 3
-            popz.v
-            exit.i
-            
-            :[2]
-            push.i [function]gml_Script____struct___Test
-            conv.i.v
-            call.i @@NullObject@@ 0
-            call.i method 2
-            dup.v 0
-            pushi.e -16
-            pop.v.v [stacktop]static.___struct___Test
-            call.i @@NewGMLObject@@ 2
-            pop.v.v self.b
-            """,
-            """
-            var a = 123;
-            b = 
-            {
-                c: a,
-                "(": a
-            };
-            """
-        );
-    }
-
-    [Fact]
     public void TestArray()
     {
         TestUtil.VerifyDecompileResult(

--- a/UnderanalyzerTest/DecompileContext.DecompileToString.Locals.cs
+++ b/UnderanalyzerTest/DecompileContext.DecompileToString.Locals.cs
@@ -1670,6 +1670,54 @@ public class DecompileContext_DecompileToString_Locals
     }
 
     [Fact]
+    public void TestStructWithImpossibleField()
+    {
+        TestUtil.VerifyDecompileResult(
+            """
+            :[0]
+            pushi.e 123
+            pop.v.i local.a
+            pushloc.v local.a
+            b [2]
+            
+            > gml_Script____struct___Test (locals=0, args=0)
+            :[1]
+            pushi.e -15
+            pushi.e 0
+            push.v [array]self.argument
+            pop.v.v self.c
+            pushi.e -15
+            pushi.e 0
+            push.v [array]self.argument
+            push.s "("
+            call.i @@This@@ 0
+            call.i variable_struct_set 3
+            popz.v
+            exit.i
+            
+            :[2]
+            push.i [function]gml_Script____struct___Test
+            conv.i.v
+            call.i @@NullObject@@ 0
+            call.i method 2
+            dup.v 0
+            pushi.e -16
+            pop.v.v [stacktop]static.___struct___Test
+            call.i @@NewGMLObject@@ 2
+            pop.v.v self.b
+            """,
+            """
+            var a = 123;
+            b = 
+            {
+                c: a,
+                "(": a
+            };
+            """
+        );
+    }
+
+    [Fact]
     public void TestArray()
     {
         TestUtil.VerifyDecompileResult(

--- a/UnderanalyzerTest/DecompileContext.DecompileToString.cs
+++ b/UnderanalyzerTest/DecompileContext.DecompileToString.cs
@@ -3426,4 +3426,51 @@ public class DecompileContext_DecompileToString
             """
         );
     }
+
+    [Fact]
+    public void TestStructWithImpossibleField()
+    {
+        TestUtil.VerifyDecompileResult(
+            """
+            pushi.e 123
+            pop.v.i local.a
+            pushloc.v local.a
+            b [2]
+            
+            > struct_func___struct__1 (locals=0, args=0)
+            :[1]
+            pushi.e -15
+            pushi.e 0
+            push.v [array]self.argument
+            pop.v.v self.c
+            pushi.e -15
+            pushi.e 0
+            push.v [array]self.argument
+            push.s "("
+            call.i @@This@@ 0
+            call.i variable_struct_set 3
+            popz.v
+            exit.i
+            
+            :[2]
+            push.i [function]struct_func___struct__1
+            conv.i.v
+            call.i @@NullObject@@ 0
+            call.i method 2
+            dup.v 0
+            pushi.e -16
+            pop.v.v [stacktop]static.___struct___1
+            call.i @@NewGMLObject@@ 2
+            pop.v.v self.b
+            """,
+            """
+            var a = 123;
+            b = 
+            {
+                c: a,
+                "(": a
+            };
+            """
+        );
+    }
 }

--- a/UnderanalyzerTest/ParseContext.Parse.cs
+++ b/UnderanalyzerTest/ParseContext.Parse.cs
@@ -1171,4 +1171,94 @@ public class ParseContext_Parse
 
         Assert.Equal(VMConstants.NewObjectFunction, ((SimpleFunctionCallNode)call.Arguments[2]).FunctionName);
     }
+
+    [Fact]
+    public void TestModernStructNames()
+    {
+        ParseContext context = TestUtil.Parse(
+            """
+            a =
+            {
+                "(": 1,
+                begin: 2
+            };
+            """,
+            new Underanalyzer.Mock.GameContextMock()
+            {
+                UsingStructSpecialCaseNames = true,
+                UsingStructAnyNonemptyString = true
+            });
+
+        Assert.Empty(context.CompileContext.Errors);
+        Assert.False(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
+    public void TestNoArbitraryStringsStructNames()
+    {
+        ParseContext context = TestUtil.Parse(
+            """
+            a =
+            {
+                "(": 1,
+                begin: 2
+            };
+            """,
+            new Underanalyzer.Mock.GameContextMock()
+            {
+                UsingStructSpecialCaseNames = true
+            });
+
+        Assert.NotEmpty(context.CompileContext.Errors);
+        Assert.True(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
+    public void TestNoArbitraryStringsStructNames2()
+    {
+        ParseContext context = TestUtil.Parse(
+            """
+            a =
+            {
+                begin: 1
+            };
+            """,
+            new Underanalyzer.Mock.GameContextMock()
+            {
+                UsingStructSpecialCaseNames = true
+            });
+
+        Assert.Empty(context.CompileContext.Errors);
+        Assert.False(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
+    public void TestOldStructNames()
+    {
+        ParseContext context = TestUtil.Parse(
+            """
+            a =
+            {
+                begin: 1
+            };
+            """);
+
+        Assert.NotEmpty(context.CompileContext.Errors);
+        Assert.True(context.CompileContext.HasErrors);
+    }
+
+    [Fact]
+    public void TestOldStructNames2()
+    {
+        ParseContext context = TestUtil.Parse(
+            """
+            a =
+            {
+                "begin": 1
+            };
+            """);
+
+        Assert.Empty(context.CompileContext.Errors);
+        Assert.False(context.CompileContext.HasErrors);
+    }
 }

--- a/UnderanalyzerTest/RoundTrip.cs
+++ b/UnderanalyzerTest/RoundTrip.cs
@@ -1644,12 +1644,12 @@ public class RoundTrip
             """
             a = 
             {
-                case: 1,
-                default: 2,
-                throw: 3,
-                function: 4,
+                "case": 1,
+                "default": 2,
+                "throw": 3,
+                "function": 4,
                 regular_variable: 5,
-                begin: 6
+                "begin": 6
             };
             """
         );
@@ -1949,6 +1949,24 @@ public class RoundTrip
             old_bug_now_fixed = $"\{{123}}";
             spaces_test = @@string@@("{ 0}", 123);
             spaces_test_2 = @@string@@("{0 }", 123);
+            """
+        );
+    }
+
+    [Fact]
+    public void TestStructWithImpossibleField()
+    {
+        TestUtil.VerifyRoundTrip(
+            """
+            function test()
+            {
+                a = 
+                {
+                    ";": 4,
+                    "hello world": "hi programmer",
+                    b: 6
+                };
+            }
             """
         );
     }

--- a/UnderanalyzerTest/RoundTrip.cs
+++ b/UnderanalyzerTest/RoundTrip.cs
@@ -1638,18 +1638,514 @@ public class RoundTrip
     }
 
     [Fact]
-    public void TestKeywordStructNames()
+    public void TestModernStructNames()
     {
         TestUtil.VerifyRoundTrip(
             """
-            a = 
+            var a = 123;
+            b = 
             {
-                "case": 1,
-                "default": 2,
-                "throw": 3,
-                "function": 4,
-                regular_variable: 5,
-                "begin": 6
+                c: a,
+                "a b": a,
+                "a\nb": a,
+                "(": a,
+                "a(": a,
+                begin: a,
+                if: a,
+                new: a,
+                "function": a,
+                string: a,
+                "end": a,
+                "self": a,
+                "other": a,
+                "global": a,
+                self: a,
+                other: a,
+                global: a,
+                true: a
+            };
+            """,
+            """
+            pushi.e 123
+            pop.v.i local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            b [2]
+
+            > struct_func___struct__1 (locals=0, args=0)
+            :[1]
+            call.i @@SetStatic@@ 0
+            pushi.e -15
+            pushi.e 0
+            push.v [array]self.argument
+            pop.v.v self.c
+            pushi.e -15
+            pushi.e 1
+            push.v [array]self.argument
+            pop.v.v self."a b"
+            pushi.e -15
+            pushi.e 2
+            push.v [array]self.argument
+            pop.v.v self."a\nb"
+            pushi.e -15
+            pushi.e 3
+            push.v [array]self.argument
+            push.s "("
+            conv.s.v
+            call.i @@This@@ 0
+            call.i variable_struct_set 3
+            popz.v
+            pushi.e -15
+            pushi.e 4
+            push.v [array]self.argument
+            pop.v.v self."a("
+            pushi.e -15
+            pushi.e 5
+            push.v [array]self.argument
+            pop.v.v self.begin
+            pushi.e -15
+            pushi.e 6
+            push.v [array]self.argument
+            pop.v.v self.if
+            pushi.e -15
+            pushi.e 7
+            push.v [array]self.argument
+            pop.v.v self.new
+            pushi.e -15
+            pushi.e 8
+            push.v [array]self.argument
+            pop.v.v self.function
+            pushi.e -15
+            pushi.e 9
+            push.v [array]self.argument
+            pop.v.v self.string
+            pushi.e -15
+            pushi.e 10
+            push.v [array]self.argument
+            pop.v.v self.end
+            pushi.e -15
+            pushi.e 11
+            push.v [array]self.argument
+            call.i @@This@@ 0
+            pushi.e -9
+            pop.v.v [stacktop]self.self
+            pushi.e -15
+            pushi.e 12
+            push.v [array]self.argument
+            call.i @@This@@ 0
+            pushi.e -9
+            pop.v.v [stacktop]self.other
+            pushi.e -15
+            pushi.e 13
+            push.v [array]self.argument
+            pop.v.v self.global
+            pushi.e -15
+            pushi.e 14
+            push.v [array]self.argument
+            call.i @@This@@ 0
+            pushi.e -9
+            pop.v.v [stacktop]self.self
+            pushi.e -15
+            pushi.e 15
+            push.v [array]self.argument
+            call.i @@This@@ 0
+            pushi.e -9
+            pop.v.v [stacktop]self.other
+            pushi.e -15
+            pushi.e 16
+            push.v [array]self.argument
+            pop.v.v self.global
+            pushi.e -15
+            pushi.e 17
+            push.v [array]self.argument
+            pop.v.v self.true
+            exit.i
+
+            :[2]
+            push.i [function]struct_func___struct__1
+            conv.i.v
+            call.i @@NullObject@@ 0
+            call.i method 2
+            dup.v 0
+            pop.v.v global.__struct__1
+            call.i @@NewGMLObject@@ 19
+            pop.v.v builtin.b
+            """,
+            """
+            var a = 123;
+            b = 
+            {
+                c: a,
+                "a b": a,
+                "a\nb": a,
+                "(": a,
+                "a(": a,
+                begin: a,
+                if: a,
+                new: a,
+                "function": a,
+                string: a,
+                "end": a,
+                self: a,
+                other: a,
+                global: a,
+                self: a,
+                other: a,
+                global: a,
+                true: a
+            };
+            """,
+            false,
+            new GameContextMock()
+            {
+                UsingSelfToBuiltin = true,
+                UsingConstructorSetStatic = true,
+                UsingNewFunctionVariables = true,
+                UsingOptimizedFunctionDeclarations = true,
+                UsingStructAnyNonemptyString = true,
+                UsingStructSpecialCaseNames = true
+            }
+        );
+    }
+
+    [Fact]
+    public void TestNoArbitraryStringsStructNames()
+    {
+        TestUtil.VerifyRoundTrip(
+            """
+            var a = 123;
+            b = 
+            {
+                case: a,
+                default: a,
+                throw: a,
+                "function": a,
+                regular_variable: a,
+                begin: a,
+                "end": a,
+                if: a,
+                "a b": a,
+                "a\nb": a,
+                "a(": a,
+                new: a,
+                "self": a,
+                "other": a,
+                "global": a,
+                self: a,
+                other: a,
+                global: a,
+                true: a
+            };
+            """,
+            """
+            :[0]
+            pushi.e 123
+            pop.v.i local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            b [2]
+
+            > struct_func___struct__1 (locals=0, args=0)
+            :[1]
+            call.i @@SetStatic@@ 0
+            pushi.e -15
+            pushi.e 0
+            push.v [array]self.argument
+            pop.v.v self.case
+            pushi.e -15
+            pushi.e 1
+            push.v [array]self.argument
+            pop.v.v self.default
+            pushi.e -15
+            pushi.e 2
+            push.v [array]self.argument
+            pop.v.v self.throw
+            pushi.e -15
+            pushi.e 3
+            push.v [array]self.argument
+            pop.v.v self.function
+            pushi.e -15
+            pushi.e 4
+            push.v [array]self.argument
+            pop.v.v self.regular_variable
+            pushi.e -15
+            pushi.e 5
+            push.v [array]self.argument
+            pop.v.v self.begin
+            pushi.e -15
+            pushi.e 6
+            push.v [array]self.argument
+            pop.v.v self.end
+            pushi.e -15
+            pushi.e 7
+            push.v [array]self.argument
+            pop.v.v self.if
+            pushi.e -15
+            pushi.e 8
+            push.v [array]self.argument
+            pop.v.v self."a b"
+            pushi.e -15
+            pushi.e 9
+            push.v [array]self.argument
+            pop.v.v self."a\nb"
+            pushi.e -15
+            pushi.e 10
+            push.v [array]self.argument
+            pop.v.v self."a("
+            pushi.e -15
+            pushi.e 11
+            push.v [array]self.argument
+            pop.v.v self.new
+            pushi.e -15
+            pushi.e 12
+            push.v [array]self.argument
+            call.i @@This@@ 0
+            pushi.e -9
+            pop.v.v [stacktop]self.self
+            pushi.e -15
+            pushi.e 13
+            push.v [array]self.argument
+            call.i @@This@@ 0
+            pushi.e -9
+            pop.v.v [stacktop]self.other
+            pushi.e -15
+            pushi.e 14
+            push.v [array]self.argument
+            pop.v.v self.global
+            pushi.e -15
+            pushi.e 15
+            push.v [array]self.argument
+            call.i @@This@@ 0
+            pushi.e -9
+            pop.v.v [stacktop]self.self
+            pushi.e -15
+            pushi.e 16
+            push.v [array]self.argument
+            call.i @@This@@ 0
+            pushi.e -9
+            pop.v.v [stacktop]self.other
+            pushi.e -15
+            pushi.e 17
+            push.v [array]self.argument
+            pop.v.v self.global
+            pushi.e -15
+            pushi.e 18
+            push.v [array]self.argument
+            pop.v.v self.true
+            exit.i
+
+            :[2]
+            push.i [function]struct_func___struct__1
+            conv.i.v
+            call.i @@NullObject@@ 0
+            call.i method 2
+            dup.v 0
+            pushi.e -5
+            pop.v.v [stacktop]global.__struct__1
+            call.i @@NewGMLObject@@ 20
+            pop.v.v builtin.b
+            """,
+            """
+            var a = 123;
+            b = 
+            {
+                case: a,
+                default: a,
+                throw: a,
+                "function": a,
+                regular_variable: a,
+                begin: a,
+                "end": a,
+                if: a,
+                "a b": a,
+                "a\nb": a,
+                "a(": a,
+                new: a,
+                self: a,
+                other: a,
+                global: a,
+                self: a,
+                other: a,
+                global: a,
+                true: a
+            };
+            """,
+            false,
+            new GameContextMock()
+            {
+                UsingSelfToBuiltin = true,
+                UsingConstructorSetStatic = true,
+                UsingNewFunctionVariables = true,
+                UsingStructSpecialCaseNames = true
+            }
+        );
+    }
+
+    [Fact]
+    public void TestOldStructNames()
+    {
+        TestUtil.VerifyRoundTrip(
+            """
+            var a = 123;
+            b = 
+            {
+                c: a,
+                "a b": a,
+                "a\nb": a,
+                "a(": a,
+                "begin": a,
+                "end": a,
+                "new": a,
+                "self": a,
+                "other": a,
+                "global": a,
+                self: a,
+                other: a,
+                global: a,
+                true: a
+            };
+            """,
+            """
+            pushi.e 123
+            pop.v.i local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            pushloc.v local.a
+            b [2]
+
+            > struct_func___struct__1 (locals=0, args=0)
+            :[1]
+            pushi.e -15
+            pushi.e 0
+            push.v [array]self.argument
+            pop.v.v self.c
+            pushi.e -15
+            pushi.e 1
+            push.v [array]self.argument
+            pop.v.v self."a b"
+            pushi.e -15
+            pushi.e 2
+            push.v [array]self.argument
+            pop.v.v self."a\nb"
+            pushi.e -15
+            pushi.e 3
+            push.v [array]self.argument
+            pop.v.v self."a("
+            pushi.e -15
+            pushi.e 4
+            push.v [array]self.argument
+            pop.v.v self.begin
+            pushi.e -15
+            pushi.e 5
+            push.v [array]self.argument
+            pop.v.v self.end
+            pushi.e -15
+            pushi.e 6
+            push.v [array]self.argument
+            pop.v.v self.new
+            pushi.e -15
+            pushi.e 7
+            push.v [array]self.argument
+            pop.v.v self.self
+            pushi.e -15
+            pushi.e 8
+            push.v [array]self.argument
+            pop.v.v self.other
+            pushi.e -15
+            pushi.e 9
+            push.v [array]self.argument
+            pop.v.v self.global
+            pushi.e -15
+            pushi.e 10
+            push.v [array]self.argument
+            pop.v.v self.self
+            pushi.e -15
+            pushi.e 11
+            push.v [array]self.argument
+            pop.v.v self.other
+            pushi.e -15
+            pushi.e 12
+            push.v [array]self.argument
+            pop.v.v self.global
+            pushi.e -15
+            pushi.e 13
+            push.v [array]self.argument
+            pop.v.v self.true
+            exit.i
+
+            :[2]
+            push.i [function]struct_func___struct__1
+            conv.i.v
+            call.i @@NullObject@@ 0
+            call.i method 2
+            dup.v 0
+            pushi.e -16
+            pop.v.v [stacktop]static.__struct__1
+            call.i @@NewGMLObject@@ 15
+            pop.v.v self.b
+            """,
+            """
+            var a = 123;
+            b = 
+            {
+                c: a,
+                "a b": a,
+                "a\nb": a,
+                "a(": a,
+                "begin": a,
+                "end": a,
+                "new": a,
+                self: a,
+                other: a,
+                global: a,
+                self: a,
+                other: a,
+                global: a,
+                true: a
             };
             """
         );
@@ -1967,7 +2463,12 @@ public class RoundTrip
                     b: 6
                 };
             }
-            """
-        );
+            """,
+            true,
+            new GameContextMock()
+            {
+                UsingStructAnyNonemptyString = true,
+                UsingStructSpecialCaseNames = true
+            });
     }
 }

--- a/UnderanalyzerTest/TestUtil.cs
+++ b/UnderanalyzerTest/TestUtil.cs
@@ -246,13 +246,10 @@ internal static class TestUtil
     }
 
     /// <summary>
-    /// Asserts that the given GML code is equivalent to the given bytecode assembly.
+    /// Asserts that the given generated code entry is the same as the given assembly.
     /// </summary>
-    public static void AssertBytecode(string code, string assembly, bool isGlobalScript = false, GameContextMock? gameContext = null)
+    private static void AssertCodeSameAsAssembly(GMCode generated, string assembly, GameContextMock? gameContext = null)
     {
-        // Generate compiled code
-        GMCode generated = CompileCode(code, isGlobalScript, gameContext);
-
         // Generate comparison code
         GMCode comparison = GetCode(assembly, gameContext);
 
@@ -299,7 +296,7 @@ internal static class TestUtil
 
                 // Self sometimes becomes builtin/stacktop for instructions, but not the actual variable itself
                 if (actualInstr.ResolvedVariable!.InstanceType != IGMInstruction.InstanceType.Self ||
-                    variable.InstanceType is not (IGMInstruction.InstanceType.Builtin or 
+                    variable.InstanceType is not (IGMInstruction.InstanceType.Builtin or
                                                   IGMInstruction.InstanceType.StackTop))
                 {
                     Assert.Equal(variable.InstanceType, actualInstr.ResolvedVariable!.InstanceType);
@@ -319,6 +316,17 @@ internal static class TestUtil
             }
         }
         Assert.Equal(comparison.InstructionCount, generated.Instructions.Count);
+    }
+
+    /// <summary>
+    /// Asserts that the given GML code is equivalent to the given bytecode assembly.
+    /// </summary>
+    public static void AssertBytecode(string code, string assembly, bool isGlobalScript = false, GameContextMock? gameContext = null)
+    {
+        // Generate compiled code
+        GMCode generated = CompileCode(code, isGlobalScript, gameContext);
+
+        AssertCodeSameAsAssembly(generated, assembly, gameContext);
     }
 
     /// <summary>
@@ -348,6 +356,27 @@ internal static class TestUtil
 
         // Compile code
         GMCode generated = CompileCode(code, isGlobalScript, gameContext);
+
+        // Decompile generated code entry
+        DecompileContext decompilerContext = new(gameContext, generated, decompileSettings);
+        string decompileResult = decompilerContext.DecompileToString();
+
+        // Ensure code is identical to expected decompilation
+        Assert.Equal(expected.Trim().ReplaceLineEndings("\n"), decompileResult.Trim());
+    }
+
+    /// <summary>
+    /// Compiles the given GML code, asserts bytecode assembly, then decompiles it, ensuring the decompilation result is identical to the expected result.
+    /// </summary>
+    public static void VerifyRoundTrip(string code, string assembly, string expected, bool isGlobalScript = false, GameContextMock? gameContext = null, DecompileSettings? decompileSettings = null)
+    {
+        gameContext ??= new();
+
+        // Compile code
+        GMCode generated = CompileCode(code, isGlobalScript, gameContext);
+
+        // Assert bytecode
+        AssertCodeSameAsAssembly(generated, assembly);
 
         // Decompile generated code entry
         DecompileContext decompilerContext = new(gameContext, generated, decompileSettings);


### PR DESCRIPTION
solves #23 

This solves the issue of struct literals with impossible fields compiling to `{ variable_struct_set(self, "(", value) }` on both the compiler and decompiler by putting them in quotes. (e.g. `{ "(": value }`)


However, there are a few (fixable) caveats with this change, all GML keywords are now also quoted in order to prevent errors with compilation.